### PR TITLE
feat: Update `common-builder` to use `common-wit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "bytes",
  "common-bundler",
  "common-test-fixtures",
+ "common-wit",
  "mime_guess",
  "redb",
  "reqwest",

--- a/rust/common-builder/Cargo.toml
+++ b/rust/common-builder/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
+common-wit = { workspace = true }
+
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["multipart", "macros"] }

--- a/rust/common-builder/src/bake/mod.rs
+++ b/rust/common-builder/src/bake/mod.rs
@@ -1,11 +1,12 @@
-mod baker;
 mod fs;
 mod javascript;
 mod python;
+mod r#trait;
 
-pub use baker::*;
+use common_wit::WitTarget;
 pub use javascript::*;
 pub use python::*;
+pub use r#trait::*;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -19,25 +20,15 @@ pub enum Baker {
 }
 
 #[async_trait]
-impl Bakerlike for Baker {
+impl Bake for Baker {
     async fn bake(
         &self,
-        world: &str,
-        wit: Vec<Bytes>,
+        target: WitTarget,
         source_code: Bytes,
-        library: Vec<Bytes>,
     ) -> Result<Bytes, crate::BuilderError> {
         match self {
-            Baker::JavaScript => {
-                (JavaScriptBaker {})
-                    .bake(world, wit, source_code, library)
-                    .await
-            }
-            Baker::Python => {
-                (PythonBaker {})
-                    .bake(world, wit, source_code, library)
-                    .await
-            }
+            Baker::JavaScript => (JavaScriptBaker {}).bake(target, source_code).await,
+            Baker::Python => (PythonBaker {}).bake(target, source_code).await,
         }
     }
 }

--- a/rust/common-builder/src/bake/trait.rs
+++ b/rust/common-builder/src/bake/trait.rs
@@ -1,19 +1,14 @@
 use crate::BuilderError;
 use async_trait::async_trait;
 use bytes::Bytes;
+use common_wit::WitTarget;
 
 /// A trait to build a WASM artifact containing WIT modules, and
 /// source code to be executed within the artifact, where specific
 /// implementations of [Bake] provide a runtime to execute that source.
 #[async_trait]
-pub trait Bakerlike {
+pub trait Bake {
     /// Build a WASM artifact containing the WIT modules and means
     /// to execute `source_code`.
-    async fn bake(
-        &self,
-        world: &str,
-        wit: Vec<Bytes>,
-        source_code: Bytes,
-        library: Vec<Bytes>,
-    ) -> Result<Bytes, BuilderError>;
+    async fn bake(&self, target: WitTarget, source_code: Bytes) -> Result<Bytes, BuilderError>;
 }

--- a/rust/common-builder/src/error.rs
+++ b/rust/common-builder/src/error.rs
@@ -1,5 +1,3 @@
-// use std::fmt::Display;
-
 use axum::{
     extract::multipart::MultipartError,
     http::{uri::InvalidUri, StatusCode},

--- a/rust/common-builder/tests/server.rs
+++ b/rust/common-builder/tests/server.rs
@@ -19,7 +19,9 @@ async fn it_bundles_javascript() -> anyhow::Result<()> {
 "#,
         esm_addr
     );
-    let form = Form::new().part("source", Part::text(source).file_name("foo.js"));
+    let form = Form::new()
+        .part("source", Part::text(source).file_name("foo.js"))
+        .part("target", Part::text("common:module"));
 
     let res = Client::new()
         .post(format!("http://{}/api/v0/bundle", addr))
@@ -35,7 +37,45 @@ async fn it_bundles_javascript() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-#[ignore]
 async fn it_builds_javascript_modules() -> anyhow::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let handler = tokio::spawn(async { serve(listener).await.unwrap() });
+
+    let source = r#"import { read, write } from 'common:io/state@0.0.1';
+
+export class Body {
+    run() {
+        const foo = read('foo');
+        const value = foo?.deref();
+
+        write('baz', {
+          tag: 'string',
+          val: 'quux'
+        });
+    }
+}
+
+export const module = {
+  Body,
+
+  create() {
+      return new Body();
+  }
+};"#;
+    let form = Form::new()
+        .part("source", Part::text(source).file_name("foo.js"))
+        .part("target", Part::text("common:module"));
+
+    let res = Client::new()
+        .post(format!("http://{}/api/v0/module", addr))
+        .multipart(form)
+        .send()
+        .await?;
+
+    assert_eq!(res.status(), 200);
+    assert!(res.text().await?.starts_with("{\"id\":"));
+
+    handler.abort();
     Ok(())
 }

--- a/rust/common-wit/Cargo.toml
+++ b/rust/common-wit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common-wit"
-description = "Common library over WIT definitions"
+description = "Common library of shared WIT definitions"
 version = "0.1.0"
 edition = "2021"
 publish = false


### PR DESCRIPTION
This change proposes that we re-work `common-builder` a bit to use the `WitTarget` `enum` in `common-wit`. 

I anticipate that we will mainly will concern ourselves with building well-known targets over time. For now, we have one simple target: `common:module`. We can infer everything else we need to know about the build environment from that target name.