### PR TITLE
feat: add common-tracing, with a shared initialization method for executables and tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "bytes",
  "common-bundler",
  "common-test-fixtures",
+ "common-tracing",
  "mime_guess",
  "redb",
  "reqwest",
@@ -458,6 +459,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "common-test-fixtures",
+ "common-tracing",
  "deno_emit",
  "deno_graph",
  "reqwest",
@@ -476,6 +478,7 @@ dependencies = [
  "axum",
  "blake3",
  "bytes",
+ "common-tracing",
  "common-wit",
  "hyper-util",
  "mime_guess",
@@ -510,6 +513,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-tracing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "console_error_panic_hook",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-wasm",
+]
+
+[[package]]
 name = "common-wit"
 version = "0.1.0"
 dependencies = [
@@ -520,6 +534,16 @@ dependencies = [
  "tokio",
  "tracing",
  "wit-parser 0.211.1",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3610,6 +3634,17 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "rust/common-bundler",
   "rust/common-runtime",
   "rust/common-test-fixtures",
+  "rust/common-tracing",
   "rust/common-wit",
 ]
 
@@ -11,17 +12,17 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-common-builder = { path = "./rust/common-builder" }
-common-bundler = { path = "./rust/common-bundler" }
-common-test-fixtures = { path = "./rust/common-test-fixtures" }
-common-runtime = { path = "./rust/common-runtime" }
-
 anyhow = { version = "1" }
 async-trait = { version = "0.1" }
 axum = { version = "0.7" }
 blake3 = { version = "1.5" }
 bytes = { version = "1" }
 clap = { version = "4.5" }
+common-builder = { path = "./rust/common-builder" }
+common-bundler = { path = "./rust/common-bundler" }
+common-test-fixtures = { path = "./rust/common-test-fixtures" }
+common-runtime = { path = "./rust/common-runtime" }
+common-tracing = { path = "./rust/common-tracing" }
 common-wit = { path = "./rust/common-wit" }
 deno_emit = { version = "0.43" }
 deno_graph = { version = "0.79" }

--- a/rust/common-builder/Cargo.toml
+++ b/rust/common-builder/Cargo.toml
@@ -12,6 +12,7 @@ axum = { workspace = true, features = ["multipart", "macros"] }
 blake3 = { workspace = true }
 bytes = { workspace = true }
 common-bundler = { workspace = true }
+common-tracing = { workspace = true }
 mime_guess = { workspace = true }
 redb = { workspace = true }
 serde = { workspace = true }

--- a/rust/common-builder/src/bin/builder.rs
+++ b/rust/common-builder/src/bin/builder.rs
@@ -1,17 +1,12 @@
 #[macro_use]
 extern crate tracing;
 
-use std::net::SocketAddr;
-
 use common_builder::{serve, BuilderError};
-use tracing_subscriber::{fmt::Layer, layer::SubscriberExt, EnvFilter, FmtSubscriber};
+use std::net::SocketAddr;
 
 #[tokio::main]
 pub async fn main() -> Result<(), BuilderError> {
-    let subscriber = FmtSubscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-    tracing::subscriber::set_global_default(subscriber.with(Layer::default().pretty()))?;
+    common_tracing::initialize_tracing();
 
     let port = std::env::var("PORT").unwrap_or("8081".into());
     let socket_address: SocketAddr = format!("0.0.0.0:{port}").parse()?;

--- a/rust/common-builder/tests/server.rs
+++ b/rust/common-builder/tests/server.rs
@@ -7,6 +7,7 @@ use tokio::net::TcpListener;
 
 #[tokio::test]
 async fn it_bundles_javascript() -> anyhow::Result<()> {
+    common_tracing::initialize_tracing();
     let mut esm_server = common_test_fixtures::EsmTestServer::default();
     let esm_addr = esm_server.start().await?;
 
@@ -37,5 +38,6 @@ async fn it_bundles_javascript() -> anyhow::Result<()> {
 #[tokio::test]
 #[ignore]
 async fn it_builds_javascript_modules() -> anyhow::Result<()> {
+    common_tracing::initialize_tracing();
     Ok(())
 }

--- a/rust/common-bundler/Cargo.toml
+++ b/rust/common-bundler/Cargo.toml
@@ -17,4 +17,5 @@ url = { workspace = true }
 
 [dev-dependencies]
 common-test-fixtures = { workspace = true }
+common-tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/common-bundler/src/lib.rs
+++ b/rust/common-bundler/src/lib.rs
@@ -147,6 +147,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn it_bundles_javascript_from_url() -> Result<()> {
+        common_tracing::initialize_tracing();
         let mut server = EsmTestServer::default();
         let addr = server.start().await?;
         let candidate = Url::parse(&format!("http://{}/math/index.js", addr))?;
@@ -159,6 +160,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn it_bundles_typescript_from_url() -> Result<()> {
+        common_tracing::initialize_tracing();
         let mut server = EsmTestServer::default();
         let addr = server.start().await?;
         let candidate = Url::parse(&format!("http://{}/math/index.ts", addr))?;
@@ -171,6 +173,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn it_bundles_javascript_from_bytes() -> Result<()> {
+        common_tracing::initialize_tracing();
         let mut server = EsmTestServer::default();
         let addr = server.start().await?;
         let candidate = format!(
@@ -187,6 +190,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn it_skips_common_modules_when_bundling() -> Result<()> {
+        common_tracing::initialize_tracing();
         let candidate = r#"
 import { read, write } from "common:io/state@0.0.1";
 

--- a/rust/common-runtime/Cargo.toml
+++ b/rust/common-runtime/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-common-wit = { workspace = true }
-
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["multipart", "macros"] }
 blake3 = { workspace = true }
 bytes = { workspace = true }
+common-tracing = { workspace = true }
+common-wit = { workspace = true }
 hyper-util = { workspace = true }
 mime_guess = { workspace = true }
 redb = { workspace = true }

--- a/rust/common-runtime/src/bin/runtime.rs
+++ b/rust/common-runtime/src/bin/runtime.rs
@@ -1,1 +1,3 @@
-fn main() {}
+fn main() {
+    common_tracing::initialize_tracing();
+}

--- a/rust/common-tracing/Cargo.toml
+++ b/rust/common-tracing/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "common-tracing"
+description = "Shared utilities for common crates."
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tracing-subscriber = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1"
+tracing-wasm = "~0.2"

--- a/rust/common-tracing/README.md
+++ b/rust/common-tracing/README.md
@@ -1,0 +1,4 @@
+# common-tracing
+
+Shared log based tracing functionality.
+

--- a/rust/common-tracing/src/lib.rs
+++ b/rust/common-tracing/src/lib.rs
@@ -1,0 +1,45 @@
+#![warn(missing_docs)]
+
+//! A library containing shared tracing functionality across common crates.
+
+#[cfg(target_arch = "wasm32")]
+mod inner {
+    use std::sync::Once;
+    static INITIALIZE_TRACING: Once = Once::new();
+
+    /// Initialize tracing-based logging.
+    pub fn initialize_tracing() {
+        INITIALIZE_TRACING.call_once(|| {
+            console_error_panic_hook::set_once();
+            tracing_wasm::set_as_global_default();
+        })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod inner {
+    use anyhow::Result;
+    use std::sync::Once;
+    use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+    static INITIALIZE_TRACING: Once = Once::new();
+
+    /// Initialize tracing-based logging.
+    pub fn initialize_tracing() {
+        INITIALIZE_TRACING.call_once(|| {
+            if let Err(error) = initialize_tracing_subscriber() {
+                println!("Failed to initialize tracing: {}", error);
+            }
+        });
+    }
+
+    fn initialize_tracing_subscriber() -> Result<()> {
+        let subscriber = FmtSubscriber::builder()
+            .with_env_filter(EnvFilter::from_default_env())
+            .finish();
+        tracing::subscriber::set_global_default(subscriber)?;
+        Ok(())
+    }
+}
+
+pub use inner::*;


### PR DESCRIPTION
Initial work here for better logs while developing the builder, more work to be done for wasm32 support and more configurations/customizations to the logging