### PR TITLE
feat: add #[common_tracing] to instrument tests with tracing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "blake3",
  "bytes",
  "common-test-fixtures",
+ "common-tracing",
  "common-wit",
  "deno_emit",
  "deno_graph",
@@ -522,6 +523,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-macros"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "common-runtime"
 version = "0.1.0"
 dependencies = [
@@ -533,6 +542,7 @@ dependencies = [
  "bytes",
  "common-builder",
  "common-test-fixtures",
+ "common-tracing",
  "common-wit",
  "http 1.1.0",
  "hyper-util",
@@ -573,6 +583,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-tracing"
+version = "0.1.0"
+dependencies = [
+ "common-macros",
+ "console_error_panic_hook",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-wasm",
+]
+
+[[package]]
 name = "common-wit"
 version = "0.1.0"
 dependencies = [
@@ -583,6 +604,16 @@ dependencies = [
  "tokio",
  "tracing",
  "wit-parser 0.212.0",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2729,9 +2760,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3931,6 +3962,17 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4575c663a174420fa2d78f4108ff68f65bf2fbb7dd89f33749b6e826b3626e07"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [workspace]
 members = [
   "rust/common-builder",
+  "rust/common-macros",
   "rust/common-runtime",
   "rust/common-test-fixtures",
+  "rust/common-tracing",
   "rust/common-wit",
 ]
 
@@ -10,11 +12,6 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-common-builder = { path = "./rust/common-builder" }
-common-runtime = { path = "./rust/common-runtime" }
-common-test-fixtures = { path = "./rust/common-test-fixtures" }
-common-wit = { path = "./rust/common-wit" }
-
 anyhow = { version = "1" }
 async-stream = { version = "0.3" }
 async-trait = { version = "0.1" }
@@ -22,6 +19,12 @@ axum = { version = "0.7" }
 blake3 = { version = "1.5" }
 bytes = { version = "1" }
 clap = { version = "4.5" }
+common-builder = { path = "./rust/common-builder" }
+common-runtime = { path = "./rust/common-runtime" }
+common-macros = { path = "./rust/common-macros" }
+common-test-fixtures = { path = "./rust/common-test-fixtures" }
+common-tracing = { path = "./rust/common-tracing" }
+common-wit = { path = "./rust/common-wit" }
 deno_emit = { version = "0.43" }
 deno_graph = { version = "0.79" }
 http = { version = "1.1" }

--- a/rust/common-builder/Cargo.toml
+++ b/rust/common-builder/Cargo.toml
@@ -13,6 +13,7 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
+common-tracing = { workspace = true }
 deno_emit = { workspace = true }
 deno_graph = { workspace = true }
 mime_guess = { workspace = true }
@@ -32,7 +33,6 @@ wit-parser = { workspace = true }
 
 [dev-dependencies]
 common-test-fixtures = { workspace = true }
-
 reqwest = { workspace = true, features = ["multipart"] }
 tracing-subscriber = { workspace = true }
 

--- a/rust/common-builder/src/bin/builder.rs
+++ b/rust/common-builder/src/bin/builder.rs
@@ -1,17 +1,16 @@
 #[macro_use]
 extern crate tracing;
 
-use std::net::SocketAddr;
-
 use common_builder::{serve, BuilderError};
-use tracing_subscriber::{fmt::Layer, layer::SubscriberExt, EnvFilter, FmtSubscriber};
+use std::net::SocketAddr;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[tokio::main]
 pub async fn main() -> Result<(), BuilderError> {
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
-    tracing::subscriber::set_global_default(subscriber.with(Layer::default().pretty()))?;
+    tracing::subscriber::set_global_default(subscriber)?;
 
     let port = std::env::var("PORT").unwrap_or("8081".into());
     let socket_address: SocketAddr = format!("0.0.0.0:{port}").parse()?;

--- a/rust/common-builder/src/bundle.rs
+++ b/rust/common-builder/src/bundle.rs
@@ -149,6 +149,7 @@ pub mod tests {
     use crate::JavaScriptBundler;
     use anyhow::Result;
     use common_test_fixtures::EsmTestServer;
+    use common_tracing::*;
     use url::Url;
 
     fn assert_math_bundle(bundle: &str) {
@@ -158,6 +159,7 @@ pub mod tests {
     }
 
     #[tokio::test]
+    #[common_tracing]
     async fn it_bundles_javascript_from_url() -> Result<()> {
         let mut server = EsmTestServer::default();
         let addr = server.start().await?;
@@ -170,6 +172,7 @@ pub mod tests {
     }
 
     #[tokio::test]
+    #[common_tracing]
     async fn it_bundles_typescript_from_url() -> Result<()> {
         let mut server = EsmTestServer::default();
         let addr = server.start().await?;
@@ -182,6 +185,7 @@ pub mod tests {
     }
 
     #[tokio::test]
+    #[common_tracing]
     async fn it_bundles_javascript_from_bytes() -> Result<()> {
         let mut server = EsmTestServer::default();
         let addr = server.start().await?;
@@ -198,6 +202,7 @@ pub mod tests {
     }
 
     #[tokio::test]
+    #[common_tracing]
     async fn it_skips_common_modules_when_bundling() -> Result<()> {
         let candidate = r#"
 import { read, write } from "common:io/state@0.0.1";

--- a/rust/common-builder/tests/server.rs
+++ b/rust/common-builder/tests/server.rs
@@ -1,7 +1,3 @@
-use common_builder::serve;
-
-use common_test_fixtures::sources::common::BASIC_MODULE_JS;
-
 use common_builder::protos::{
     builder::{
         builder_client::BuilderClient, BuildComponentRequest, BuildComponentResponse,
@@ -9,9 +5,13 @@ use common_builder::protos::{
     },
     common::{ContentType, ModuleSource, SourceCode, Target},
 };
+use common_builder::serve;
+use common_test_fixtures::sources::common::BASIC_MODULE_JS;
+use common_tracing::*;
 use tokio::net::TcpListener;
 
 #[tokio::test]
+#[common_tracing]
 async fn it_bundles_javascript() -> anyhow::Result<()> {
     let mut esm_server = common_test_fixtures::EsmTestServer::default();
     let esm_addr = esm_server.start().await?;
@@ -54,6 +54,7 @@ async fn it_bundles_javascript() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[common_tracing]
 async fn it_builds_javascript_modules() -> anyhow::Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;

--- a/rust/common-macros/Cargo.toml
+++ b/rust/common-macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "common-macros"
+description = "Macros for common crates."
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0.36"
+syn = "2.0.68"
+
+[features]
+tracing = []

--- a/rust/common-macros/README.md
+++ b/rust/common-macros/README.md
@@ -1,0 +1,3 @@
+# common-macros
+
+Macros for common crates.

--- a/rust/common-macros/src/lib.rs
+++ b/rust/common-macros/src/lib.rs
@@ -1,0 +1,38 @@
+#![warn(missing_docs)]
+#![allow(unused)]
+
+//! Macros for common crates.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+extern crate proc_macro;
+
+#[cfg(feature = "tracing")]
+#[proc_macro_attribute]
+/// An attribute macro for decorating tests with an
+/// initialized [tracing_subscriber::Subscriber].
+/// Requires the `common_tracing` dependency.
+///
+/// Implementation defined in `common_tracing::implementation::common_tracing_impl`
+pub fn common_tracing(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+
+    let ItemFn {
+        sig,
+        vis,
+        block,
+        attrs,
+    } = input;
+    let statements = block.stmts;
+
+    quote!(
+        #(#attrs)*
+        #vis #sig {
+            common_tracing::macro_impl::common_tracing_impl();
+            #(#statements)*
+        }
+    )
+    .into()
+}

--- a/rust/common-runtime/Cargo.toml
+++ b/rust/common-runtime/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-common-wit = { workspace = true }
-
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 async-stream = { workspace = true }
 axum = { workspace = true, features = ["multipart", "macros"] }
 blake3 = { workspace = true }
 bytes = { workspace = true }
+common-tracing = { workspace = true }
+common-wit = { workspace = true }
 http = { workspace = true }
 hyper-util = { workspace = true }
 mime_guess = { workspace = true }

--- a/rust/common-runtime/src/bin/runtime.rs
+++ b/rust/common-runtime/src/bin/runtime.rs
@@ -4,15 +4,14 @@ extern crate tracing;
 use std::net::SocketAddr;
 
 use common_runtime::{serve, CommonRuntimeError};
-use tracing_subscriber::{fmt::Layer, layer::SubscriberExt, EnvFilter, FmtSubscriber};
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[tokio::main]
 pub async fn main() -> Result<(), CommonRuntimeError> {
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
         .finish();
-    tracing::subscriber::set_global_default(subscriber.with(Layer::default().pretty()))
-        .expect("Failed to configure tracing");
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to configure tracing");
 
     let port = std::env::var("PORT").unwrap_or("8081".into());
     let socket_address: SocketAddr = format!("0.0.0.0:{port}")

--- a/rust/common-tracing/Cargo.toml
+++ b/rust/common-tracing/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "common-tracing"
+description = "Shared utilities for common crates."
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+common-macros = { workspace = true, features = ["tracing"] }
+tracing = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tracing-subscriber = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1"
+tracing-wasm = "~0.2"

--- a/rust/common-tracing/README.md
+++ b/rust/common-tracing/README.md
@@ -1,0 +1,4 @@
+# common-tracing
+
+Shared log based tracing functionality.
+

--- a/rust/common-tracing/src/lib.rs
+++ b/rust/common-tracing/src/lib.rs
@@ -1,0 +1,14 @@
+#![warn(missing_docs)]
+
+//! A library containing shared tracing functionality across common crates.
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate common_macros;
+
+/// Contains implementation for the `#[common_tracing]` macro.
+/// Prefer using the [common_tracing::common_tracing] macro over
+/// calling these functions directly.
+pub mod macro_impl;
+
+pub use common_macros::common_tracing;

--- a/rust/common-tracing/src/macro_impl.rs
+++ b/rust/common-tracing/src/macro_impl.rs
@@ -1,0 +1,43 @@
+#[cfg(target_arch = "wasm32")]
+mod inner {
+    use std::sync::Once;
+    static INITIALIZE_TRACING: Once = Once::new();
+
+    /// Do not call directly.
+    /// See [common_tracing::common_tracing].
+    pub fn common_tracing_impl() {
+        INITIALIZE_TRACING.call_once(|| {
+            console_error_panic_hook::set_once();
+            tracing_wasm::set_as_global_default();
+        })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod inner {
+    use std::sync::Once;
+    use tracing::subscriber::SetGlobalDefaultError;
+    use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+    static INITIALIZE_TRACING: Once = Once::new();
+
+    /// Do not call directly.
+    /// See [common_tracing::common_tracing].
+    pub fn common_tracing_impl() {
+        INITIALIZE_TRACING.call_once(|| {
+            if let Err(error) = initialize_tracing_subscriber() {
+                println!("Failed to initialize tracing: {}", error);
+            }
+        });
+    }
+
+    fn initialize_tracing_subscriber() -> Result<(), SetGlobalDefaultError> {
+        let subscriber = FmtSubscriber::builder()
+            .with_env_filter(EnvFilter::from_default_env())
+            .finish();
+        tracing::subscriber::set_global_default(subscriber)?;
+        Ok(())
+    }
+}
+
+pub use inner::*;


### PR DESCRIPTION
* Introduce `common-tracing` and its proc-macro companion `common-tracing-macros`
* `common_tracing::common_tracing` is an attribute proc macro for decorating unit tests with a subscriber that reports logs
* Can add custom `Layer` types in the future for use in both tests and binaries; default is sufficient for now
* Implementation of macro lives in `common-tracing` as the rewritten function needs visibility to the function to call in lieu of inlining everything. Lots of unsatisfying options here, but this is the most simple I've found so far. **Maybe** the `quote!` can be concatenated with a reference to a `common_tracing_macros`-defined function such that it doesn't look for a local function of the same name in tests (hygiene) nor require visibility, but solves our current logging needs for now

via https://github.com/commontoolsinc/system/pull/11#discussion_r1659405164