### PR TITLE
[WIP] feat: introduce polyfill/browser-compat transpiling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -436,6 +436,7 @@ dependencies = [
  "common-bundler",
  "common-test-fixtures",
  "common-wit",
+ "js-component-bindgen",
  "mime_guess",
  "redb",
  "reqwest",
@@ -449,6 +450,7 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
+ "wasmtime-environ",
  "wit-parser 0.211.1",
 ]
 
@@ -1307,6 +1309,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1600,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-component-bindgen"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe1b7b156bc7f489a100e452bf2524281126b236f1ddb28b9c617e1ad358c92"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "heck 0.5.0",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
+ "wasmtime-environ",
+ "wit-bindgen-core",
+ "wit-component",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -2746,6 +2771,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3895,6 +3929,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,7 +4260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.4.1",
  "indexmap",
  "wit-parser 0.209.1",
 ]
@@ -4287,7 +4337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557567f2793508760cd855f7659b7a0b9dc4dbc451f53f1415d6943a15311ade"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "shellexpand",
@@ -4539,6 +4589,37 @@ checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
  "bitflags 2.6.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d4706efb67fadfbbde77955b299b111dd096e6776d8c6561d92f6147941880"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.209.1",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.209.1",
+ "wasm-metadata",
+ "wasmparser 0.209.1",
+ "wat",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]

--- a/rust/common-builder/Cargo.toml
+++ b/rust/common-builder/Cargo.toml
@@ -14,6 +14,7 @@ axum = { workspace = true, features = ["multipart", "macros"] }
 blake3 = { workspace = true }
 bytes = { workspace = true }
 common-bundler = { workspace = true }
+js-component-bindgen = { workspace = true }
 mime_guess = { workspace = true }
 redb = { workspace = true }
 serde = { workspace = true }
@@ -26,6 +27,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras"] }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
+wasmtime-environ = { workspace = true }
 wit-parser = { workspace = true }
 
 [dev-dependencies]

--- a/rust/common-builder/src/lib.rs
+++ b/rust/common-builder/src/lib.rs
@@ -8,6 +8,7 @@ extern crate tracing;
 mod bake;
 mod error;
 mod openapi;
+mod polyfill;
 mod routes;
 mod serve;
 mod storage;

--- a/rust/common-builder/src/polyfill/mod.rs
+++ b/rust/common-builder/src/polyfill/mod.rs
@@ -1,0 +1,195 @@
+use anyhow::Result;
+use js_component_bindgen::{transpile, InstantiationMode, TranspileOpts, Transpiled};
+use std::collections::HashMap;
+use wasmtime_environ::component::Export as WasmtimeExport;
+
+//pub type Mappings = HashMap<String, String>;
+pub struct Mappings {
+    map: HashMap<String, String>,
+}
+
+impl Mappings {
+    pub fn into_map(self) -> HashMap<String, String> {
+        self.map
+    }
+}
+
+impl From<HashMap<String, String>> for Mappings {
+    fn from(map: HashMap<String, String>) -> Self {
+        Mappings { map }
+    }
+}
+
+impl From<Mappings> for HashMap<String, String> {
+    fn from(value: Mappings) -> Self {
+        value.into_map()
+    }
+}
+
+impl<S> FromIterator<(S, S)> for Mappings
+where
+    S: ToString,
+{
+    fn from_iter<T: IntoIterator<Item = (S, S)>>(iter: T) -> Self {
+        let mut map = HashMap::default();
+        for (k, v) in iter.into_iter() {
+            map.insert(k.to_string(), v.to_string());
+        }
+        Mappings { map }
+    }
+}
+/// Type of instantiation for a WASM module.
+pub enum Instantiation {
+    /// The WASM module is automatically instantiated.
+    Automatic,
+    /// The WASM module needs to be manually instantiated.
+    Manual,
+}
+
+/// Type of WASM exports used in [Artifacts].
+#[derive(Debug)]
+pub enum ExportType {
+    /// Export is a function.
+    Function,
+    /// Export is an instance.
+    Instance,
+}
+
+/// Representing all generated artifacts from a [polyfill]
+/// invocation containing files, imports and exports.
+#[derive(Debug)]
+pub struct Artifacts {
+    /// Sequence of file tuples, containing the filename and bytes.
+    pub files: Vec<(String, Vec<u8>)>,
+    /// Sequence of import function names.
+    pub imports: Vec<String>,
+    /// Sequence of export function names and their types.
+    pub exports: Vec<(String, ExportType)>,
+}
+
+/// Take a WASM component with optional mappings and generate
+/// a suite of [Artifacts] resulting in a polyfilled version.
+pub fn polyfill(
+    name: &str,
+    component: Vec<u8>,
+    mappings: Option<Mappings>,
+    instantiation: Option<Instantiation>,
+) -> Result<Artifacts> {
+    let options = TranspileOpts {
+        name: name.to_owned(),
+        map: mappings.map(|m| m.into()),
+        no_typescript: true,
+        instantiation: instantiation
+            .unwrap_or_else(|| Instantiation::Automatic)
+            .into(),
+        import_bindings: None,
+        no_nodejs_compat: true,
+        base64_cutoff: 1024,
+        tla_compat: false,
+        valid_lifting_optimization: false,
+        tracing: false,
+        no_namespaced_exports: true,
+        multi_memory: false,
+    };
+
+    transpile(&component, options)
+        .map(|transpiled| transpiled.into())
+        .map_err(|error| anyhow::anyhow!("{}", error))
+}
+
+impl From<Instantiation> for Option<InstantiationMode> {
+    fn from(value: Instantiation) -> Self {
+        match value {
+            Instantiation::Automatic => None,
+            Instantiation::Manual => Some(InstantiationMode::Async),
+        }
+    }
+}
+
+impl From<Transpiled> for Artifacts {
+    fn from(value: Transpiled) -> Self {
+        Artifacts {
+            imports: value.imports,
+            exports: value
+                .exports
+                .into_iter()
+                .map(|(name, export)| {
+                    let export_type = match export {
+                        WasmtimeExport::LiftedFunction { .. } => ExportType::Function,
+                        WasmtimeExport::Instance { .. } => ExportType::Instance,
+                        _ => panic!("Unexpected export type"),
+                    };
+                    (name, export_type)
+                })
+                .collect(),
+            files: value.files,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Bake, JavaScriptBaker};
+    use super::*;
+    use anyhow::Result;
+    use bytes::Bytes;
+    use common_wit::WitTarget;
+
+    const WASI_MAPPINGS: [(&str, &str); 7] = [
+        ("wasi:cli/*", "/wasi-shim/cli.js#*"),
+        ("wasi:clocks/*", "/wasi-shim/clocks.js#*"),
+        ("wasi:filesystem/*", "/wasi-shim/filesystem.js#*"),
+        ("wasi:http/*", "/wasi-shim/http.js#*"),
+        ("wasi:io/*", "/wasi-shim/io.js#*"),
+        ("wasi:random/*", "/wasi-shim/random.js#*"),
+        ("wasi:sockets/*", "/wasi-shim/sockets.js#*"),
+    ];
+
+    #[tokio::test]
+    async fn it_polyfills_wasm_component() -> Result<()> {
+        let source_code = Bytes::from(
+            r#"
+import { read, write } from 'common:io/state@0.0.1';
+export class Body {
+    run() {
+        console.log('Running!');
+    }
+}
+export const module = {
+  Body,
+
+  create() {
+      console.log('Creating!');
+      return new Body();
+  }
+};"#,
+        );
+        let baker = JavaScriptBaker {};
+        let wasm_component = baker.bake(WitTarget::CommonModule, source_code).await?;
+
+        let wasi_mappings = Mappings::from_iter(
+            WASI_MAPPINGS
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect::<Vec<(String, String)>>(),
+        );
+
+        let artifacts = polyfill(
+            "mymodule",
+            wasm_component.to_vec(),
+            Some(wasi_mappings),
+            None,
+        )?;
+
+        assert!(artifacts.imports.contains(&"common:data/types".to_string()));
+        assert!(artifacts.imports.contains(&"common:io/state".to_string()));
+        assert_eq!(artifacts.files.into_iter().map(|(name, _)| name).collect::<Vec<_>>(), vec![
+            "mymodule.core.wasm".to_string(),
+            "mymodule.core2.wasm".to_string(),
+            "mymodule.core3.wasm".to_string(),
+            "mymodule.js".to_string()
+        ]);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
* Will wire up to gRPC once #12 lands
* TBD if we want to hardcode the wasi imports, and other customizations vs a single hardcoded configuration
* We could consider standardizing on some of our APIs:
  * `Bytes` vs `Vec<u8>`
  * `HashMap<String, Foo>` vs `Vec<(String, Foo)>`