### PR TITLE
feat: add a polyfill method to common-builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "common-wit",
  "deno_emit",
  "deno_graph",
+ "js-component-bindgen",
  "mime_guess",
  "redb",
  "reqwest",
@@ -716,6 +717,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wasmtime-environ",
  "wit-parser 0.212.0",
 ]
 
@@ -2149,6 +2151,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-component-bindgen"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe1b7b156bc7f489a100e452bf2524281126b236f1ddb28b9c617e1ad358c92"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "heck 0.5.0",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
+ "wasmtime-environ",
+ "wit-bindgen-core",
+ "wit-component",
+ "wit-parser 0.209.1",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3453,6 +3472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,6 +4740,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,10 +5436,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d4706efb67fadfbbde77955b299b111dd096e6776d8c6561d92f6147941880"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.209.1",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75956ff0a04a87ca0526b07199ce3b9baee899f2e4723b5b63aa296ab172ec52"
+
+[[package]]
+name = "wit-component"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
+dependencies = [
+ "anyhow",
+ "bitflags 2.6.0",
+ "indexmap 2.2.6",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.209.1",
+ "wasm-metadata",
+ "wasmparser 0.209.1",
+ "wat",
+ "wit-parser 0.209.1",
+]
 
 [[package]]
 name = "wit-parser"

--- a/proto/builder/builder.proto
+++ b/proto/builder/builder.proto
@@ -12,6 +12,15 @@ message ReadComponentRequest { string id = 1; }
 
 message ReadComponentResponse { bytes component = 1; }
 
+message BuilderFile {
+  string name = 1;
+  bytes data = 2;
+}
+
+message ReadComponentCompatRequest { string id = 1; }
+
+message ReadComponentCompatResponse { repeated BuilderFile files = 1; }
+
 message BundleSourceCodeRequest { common.ModuleSource module_source = 1; }
 
 message BundleSourceCodeResponse { string bundled_source_code = 1; }
@@ -20,6 +29,8 @@ service Builder {
   rpc BuildComponent(BuildComponentRequest) returns (BuildComponentResponse) {}
 
   rpc ReadComponent(ReadComponentRequest) returns (ReadComponentResponse) {}
+  
+  rpc ReadComponentCompat(ReadComponentCompatRequest) returns (ReadComponentCompatResponse) {}
 
   rpc BundleSourceCode(BundleSourceCodeRequest)
       returns (BundleSourceCodeResponse) {}

--- a/rust/common-builder/Cargo.toml
+++ b/rust/common-builder/Cargo.toml
@@ -17,6 +17,7 @@ common-protos = { workspace = true, features = ["builder"] }
 common-tracing = { workspace = true }
 deno_emit = { workspace = true }
 deno_graph = { workspace = true }
+js-component-bindgen = { workspace = true }
 mime_guess = { workspace = true }
 redb = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["rustls-tls", "charset", "http2", "macos-system-configuration"] }
@@ -29,6 +30,7 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
+wasmtime-environ = { workspace = true }
 wit-parser = { workspace = true }
 
 [dev-dependencies]

--- a/rust/common-builder/build.rs
+++ b/rust/common-builder/build.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+const SHIM_COMPONENTS: &[&str] = &[
+    "clocks",
+    "filesystem",
+    "http",
+    "io",
+    "random",
+    "sockets",
+    "cli",
+];
+
+fn main() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let project_root_dir = manifest_dir.parent().unwrap().parent().unwrap();
+    let wasi_shim_dir = project_root_dir
+        .join("typescript/node_modules/@bytecodealliance/preview2-shim/lib/browser/");
+
+    for component in SHIM_COMPONENTS {
+        let env_var = format!("COMMON_WASI_SHIM_{}", component.to_uppercase());
+        let file_path = wasi_shim_dir.join(format!("{}.js", component));
+
+        println!("cargo::rustc-env={}={}", env_var, file_path.display());
+        println!("cargo::rerun-if-changed={}", file_path.display());
+    }
+
+    // TODO: May have to build node_modules here
+}

--- a/rust/common-builder/src/bake/javascript.rs
+++ b/rust/common-builder/src/bake/javascript.rs
@@ -1,7 +1,5 @@
-use crate::JavaScriptBundler;
-
-use super::fs::write_file;
-use super::Bake;
+use super::{fs::write_file, Bake};
+use crate::{BuilderError, JavaScriptBundler};
 use async_trait::async_trait;
 use bytes::Bytes;
 use common_wit::{Target, WitTargetFileMap};
@@ -75,6 +73,9 @@ impl Bake for JavaScriptBaker {
 
         if !output.stderr.is_empty() {
             warn!("{}", String::from_utf8_lossy(&output.stderr));
+        }
+        if !output.status.success() {
+            return Err(BuilderError::Internal("jco exited with a failure.".into()));
         }
 
         debug!("Finished building with jco");

--- a/rust/common-builder/src/bundle/mod.rs
+++ b/rust/common-builder/src/bundle/mod.rs
@@ -1,0 +1,9 @@
+//! Utilities for compiling/bundling JavaScript into
+//! a single source.
+
+mod bundler;
+mod polyfill;
+mod wasi_shim;
+
+pub use bundler::JavaScriptBundler;
+pub use polyfill::polyfill;

--- a/rust/common-builder/src/bundle/polyfill.rs
+++ b/rust/common-builder/src/bundle/polyfill.rs
@@ -1,0 +1,192 @@
+use super::wasi_shim::WASI_MAPPINGS;
+use anyhow::Result;
+use js_component_bindgen::{transpile, InstantiationMode, TranspileOpts, Transpiled};
+use std::collections::HashMap;
+use wasmtime_environ::component::Export as WasmtimeExport;
+
+use crate::{BuilderError, JavaScriptBundler};
+
+/// Type of instantiation for a WASM module.
+pub enum Instantiation {
+    /// The WASM module is automatically instantiated.
+    Automatic,
+    /// The WASM module needs to be manually instantiated.
+    Manual,
+}
+
+/// Type of WASM exports used in [Artifacts].
+#[derive(Debug)]
+pub enum ExportType {
+    /// Export is a function.
+    Function,
+    /// Export is an instance.
+    Instance,
+}
+
+/// Representing all generated artifacts from a [polyfill]
+/// invocation containing files, imports and exports.
+#[derive(Debug)]
+pub struct Artifacts {
+    /// Sequence of file tuples, containing the filename and bytes.
+    pub files: Vec<(String, Vec<u8>)>,
+    /// Sequence of import function names.
+    pub imports: Vec<String>,
+    /// Sequence of export function names and their types.
+    pub exports: Vec<(String, ExportType)>,
+}
+
+/// Helper struct to map wasi shim imports.
+struct Mappings(HashMap<String, String>);
+
+impl<S> FromIterator<(S, S)> for Mappings
+where
+    S: ToString,
+{
+    fn from_iter<T: IntoIterator<Item = (S, S)>>(iter: T) -> Self {
+        let mut map = HashMap::default();
+        for (k, v) in iter.into_iter() {
+            map.insert(k.to_string(), v.to_string());
+        }
+        Mappings(map)
+    }
+}
+
+impl From<Mappings> for HashMap<String, String> {
+    fn from(value: Mappings) -> Self {
+        value.0
+    }
+}
+
+/// Take a WASM component and generate
+/// a suite of [Artifacts] resulting in a polyfilled version.
+pub async fn polyfill(
+    name: &str,
+    component: Vec<u8>,
+    instantiation: Option<Instantiation>,
+) -> Result<Artifacts, BuilderError> {
+    let wasi_mappings = Mappings::from_iter(WASI_MAPPINGS.into_iter()).into();
+
+    let options = TranspileOpts {
+        name: name.to_owned(),
+        map: Some(wasi_mappings),
+        no_typescript: true,
+        instantiation: instantiation
+            .unwrap_or_else(|| Instantiation::Automatic)
+            .into(),
+        import_bindings: None,
+        no_nodejs_compat: true,
+        base64_cutoff: 1024,
+        tla_compat: false,
+        valid_lifting_optimization: false,
+        tracing: false,
+        no_namespaced_exports: true,
+        multi_memory: false,
+    };
+
+    let mut artifacts: Artifacts = transpile(&component, options)
+        .map(|transpiled| transpiled.into())
+        .map_err(|error| anyhow::anyhow!("{}", error))?;
+
+    // Rewrite JS files, populating the wasi shims.
+    artifacts.files = {
+        let mut shimmed_files = vec![];
+        for (file_name, bytes) in artifacts.files.into_iter() {
+            let new_bytes = if file_name.ends_with(".js") {
+                JavaScriptBundler::bundle_from_bytes_sync(bytes::Bytes::from(bytes))
+                    .await?
+                    .into_bytes()
+            } else {
+                bytes
+            };
+            shimmed_files.push((file_name, new_bytes));
+        }
+        shimmed_files
+    };
+
+    // Filter out the "common:wasi-shim/" imports that were
+    // just bundled into the JavaScript.
+    artifacts.imports = artifacts
+        .imports
+        .into_iter()
+        .filter(|specifier| !specifier.starts_with("common:wasi-shim/"))
+        .collect();
+
+    Ok(artifacts)
+}
+
+impl From<Instantiation> for Option<InstantiationMode> {
+    fn from(value: Instantiation) -> Self {
+        match value {
+            Instantiation::Automatic => None,
+            Instantiation::Manual => Some(InstantiationMode::Async),
+        }
+    }
+}
+
+impl From<Transpiled> for Artifacts {
+    fn from(value: Transpiled) -> Self {
+        Artifacts {
+            imports: value.imports,
+            exports: value
+                .exports
+                .into_iter()
+                .map(|(name, export)| {
+                    let export_type = match export {
+                        WasmtimeExport::LiftedFunction { .. } => ExportType::Function,
+                        WasmtimeExport::Instance { .. } => ExportType::Instance,
+                        _ => panic!("Unexpected export type"),
+                    };
+                    (name, export_type)
+                })
+                .collect(),
+            files: value.files,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Bake, JavaScriptBaker};
+    use anyhow::Result;
+    use common_test_fixtures::sources::common::BASIC_MODULE_JS;
+    use common_tracing::common_tracing;
+    use common_wit::Target;
+
+    #[tokio::test]
+    #[common_tracing]
+    async fn it_polyfills_wasm_component() -> Result<()> {
+        let baker = JavaScriptBaker {};
+        let wasm_component = baker
+            .bake(Target::CommonModule, BASIC_MODULE_JS.into())
+            .await?;
+
+        let artifacts = polyfill("mymodule", wasm_component.to_vec(), None).await?;
+
+        // Check imports
+        assert!(artifacts.imports.contains(&"common:data/types".to_string()));
+        assert!(artifacts.imports.contains(&"common:io/state".to_string()));
+        assert!(!artifacts.imports.contains(&"common:wasi-shim/".to_string()));
+
+        // Check files
+        assert_eq!(
+            artifacts
+                .files
+                .iter()
+                .map(|(name, _)| name.to_owned())
+                .collect::<Vec<_>>(),
+            vec![
+                "mymodule.core.wasm".to_string(),
+                "mymodule.core2.wasm".to_string(),
+                "mymodule.core3.wasm".to_string(),
+                "mymodule.js".to_string()
+            ]
+        );
+
+        let js_out = String::from_utf8(artifacts.files[3].1.clone()).unwrap();
+        assert!(!js_out.contains("common:wasi-stub"));
+        assert!(js_out.contains("const monotonicClock ="));
+
+        Ok(())
+    }
+}

--- a/rust/common-builder/src/bundle/wasi_shim.rs
+++ b/rust/common-builder/src/bundle/wasi_shim.rs
@@ -1,0 +1,84 @@
+use crate::BuilderError;
+use anyhow::Result;
+
+/// Mappings from [crate::bundle::polyfill] generated WASI
+/// imports, to an identifier that can be replaced with
+/// a working shim.
+pub static WASI_MAPPINGS: [(&str, &str); 7] = [
+    ("wasi:cli/*", "common:wasi-shim/cli.js#*"),
+    ("wasi:clocks/*", "common:wasi-shim/clocks.js#*"),
+    ("wasi:filesystem/*", "common:wasi-shim/filesystem.js#*"),
+    ("wasi:http/*", "common:wasi-shim/http.js#*"),
+    ("wasi:io/*", "common:wasi-shim/io.js#*"),
+    ("wasi:random/*", "common:wasi-shim/random.js#*"),
+    ("wasi:sockets/*", "common:wasi-shim/sockets.js#*"),
+];
+
+/// Represents a WASI 0.2 interface implemented in JS
+/// that can be turned into a `&'static[u8]` for
+/// including in polyfilled builds.
+#[derive(Debug)]
+pub enum JavaScriptWasiShim {
+    Clocks,
+    Filesystem,
+    Http,
+    Io,
+    Random,
+    Sockets,
+    Cli,
+}
+
+impl JavaScriptWasiShim {
+    /// Maps an ES import specifier to a [JavaScriptWasiShim].
+    pub fn from_import_specifier(specifier: &str) -> Result<Self, BuilderError> {
+        match specifier {
+            "common:wasi-shim/clocks.js" => Ok(Self::Clocks),
+            "common:wasi-shim/filesystem.js" => Ok(Self::Filesystem),
+            "common:wasi-shim/http.js" => Ok(Self::Http),
+            "common:wasi-shim/io.js" => Ok(Self::Io),
+            "common:wasi-shim/random.js" => Ok(Self::Random),
+            "common:wasi-shim/sockets.js" => Ok(Self::Sockets),
+            "common:wasi-shim/cli.js" => Ok(Self::Cli),
+            _ => Err(BuilderError::ModuleNotFound),
+        }
+    }
+}
+
+impl TryFrom<JavaScriptWasiShim> for Vec<u8> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: JavaScriptWasiShim) -> Result<Self> {
+        static WASI_CLOCKS: &[u8] = include_bytes!(env!("COMMON_WASI_SHIM_CLOCKS"));
+        static WASI_FILESYSTEM: &[u8] = include_bytes!(env!("COMMON_WASI_SHIM_FILESYSTEM"));
+        static WASI_HTTP: &[u8] = include_bytes!(env!("COMMON_WASI_SHIM_HTTP"));
+        static WASI_IO: &[u8] = include_bytes!(env!("COMMON_WASI_SHIM_IO"));
+        static WASI_RANDOM: &[u8] = include_bytes!(env!("COMMON_WASI_SHIM_RANDOM"));
+        static WASI_SOCKETS: &[u8] = include_bytes!(env!("COMMON_WASI_SHIM_SOCKETS"));
+        static WASI_CLI: &[u8] = include_bytes!(env!("COMMON_WASI_SHIM_CLI"));
+
+        let source_bytes = match value {
+            JavaScriptWasiShim::Clocks => WASI_CLOCKS,
+            JavaScriptWasiShim::Filesystem => WASI_FILESYSTEM,
+            JavaScriptWasiShim::Http => WASI_HTTP,
+            JavaScriptWasiShim::Io => WASI_IO,
+            JavaScriptWasiShim::Random => WASI_RANDOM,
+            JavaScriptWasiShim::Sockets => WASI_SOCKETS,
+            JavaScriptWasiShim::Cli => WASI_CLI,
+        }
+        .to_vec();
+
+        // The loader doesn't resolve relative paths from its specifier.
+        // TODO: Look into this more to see if it can, or handle when
+        // rolling our own stubs that aren't simply copies of
+        // @bytecodealliance/preview2-shim
+        Ok(String::from_utf8(source_bytes)?
+            .replace("'./clocks.js'", "'common:wasi-shim/clocks.js'")
+            .replace("'./filesystem.js'", "'common:wasi-shim/filesystem.js'")
+            .replace("'./http.js'", "'common:wasi-shim/http.js'")
+            .replace("'./io.js'", "'common:wasi-shim/io.js'")
+            .replace("'./random.js'", "'common:wasi-shim/random.js'")
+            .replace("'./sockets.js'", "'common:wasi-shim/sockets.js'")
+            .replace("'./cli.js'", "'common:wasi-shim/cli.js'")
+            .into_bytes())
+    }
+}


### PR DESCRIPTION
add a polyfill method to common-builder that generates wasm artifacts and JS glue from a WASM component, suitable for running in non-wasm-component environments like the browser.

Future work:
* We'll have to have our own stubs that remove capabilities.
* ~~Add to grpc server.~~ Add polyfilling route on server
* Add `common:*` bindings for common wit modules.
* Consider: some guard rails on the bundler, such that `common:wasi-shim` only replaced during the polyfill step (similarly, we should not resolve new `http` modules here)
* Consider: Look into why relative imports in the preview2-shim stubs do not resolve from the importer in `deno_emit` (or can use bare imports once we have our own stubs)