### PR TITLE
fix: disable macos-13-large test runners on CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -59,7 +59,10 @@ jobs:
     needs: ['lints']
     strategy:
       matrix:
-        platform: ['ubuntu-22.04-large', 'macos-13-large']
+        # Disable 'macos-13-large' tests, currently taking ~80
+        # minutes each to finish.
+        # platform: ['ubuntu-22.04-large', 'macos-13-large']
+        platform: ['ubuntu-22.04-large']
         toolchain: ['stable', 'nightly']
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
... as they currently take ~80 minutes to complete. We can introduce this again in the future once we wrangle the dual host + wasm component builds.