### PR TITLE
chore: Perform Wasm artifact build AOT

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -54,29 +54,76 @@ jobs:
       - name: 'Run Linter'
         run: cargo +${{matrix.toolchain}} component clippy --all -- -D warnings
 
+  build-wasm-components:
+    name: 'Build Wasm Components'
+    needs: ['lints']
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: 'Install OS packages (Ubuntu)'
+        run: |
+          sudo apt update && sudo apt upgrade -y
+          sudo apt install -y protobuf-compiler libprotobuf-dev
+      - name: 'Setup Rust'
+        run: |
+          curl -sSf https://sh.rustup.rs | sh -s -- -y
+          rustup toolchain install stable 
+      - name: 'Setup Node/NPM'
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.4.4
+      - name: Install binaries from cargo
+        run: |
+          cargo binstall cargo-component cargo-nextest wit-deps-cli wasm-tools --no-confirm --force
+      - name: 'Install NPM dependencies'
+        run: |
+          npm install -g @bytecodealliance/jco @bytecodealliance/componentize-js@0.9.0
+          cd typescript
+          npm ci
+      - name: 'Run wit-deps on Wasm Component projects'
+        run: |
+          # NOTE: cargo-component doesn't invoke build.rs as expected when
+          # performing checked format
+          cd ./rust/common-javascript-interpreter
+          RUST_LOG=trace wit-deps
+      - name: 'Build Rust-based Wasm Components'
+        shell: bash
+        run: |
+          cargo component build \
+            -p common-javascript-interpreter \
+            --release
+        env:
+          RUST_LOG: debug
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wasm-components
+          path: ./target/wasm32-wasip1/release/common_javascript_interpreter.wasm
+
+
   native-target-tests:
     name: 'Native target tests'
-    needs: ['lints']
+    needs: ['lints', 'build-wasm-components']
     strategy:
       matrix:
-        platform: ['ubuntu-22.04-large', 'macos-13-large']
+        platform: ['ubuntu-latest', 'macos-13']
         toolchain: ['stable', 'nightly']
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/download-artifact@v3
       - name: 'Install OS packages (Ubuntu)'
-        if: ${{ matrix.platform == 'ubuntu-22.04-large' }}
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: |
           sudo apt update && sudo apt upgrade -y
-          sudo apt install -y protobuf-compiler libprotobuf-dev
+          sudo apt install -y protobuf-compiler libprotobuf-dev tree
       - name: 'Install OS packages (MacOS)'
-        if: ${{ matrix.platform == 'macos-13-large' }}
+        if: ${{ matrix.platform == 'macos-13' }}
         run: |
-          brew install protobuf
-      - name: 'Setup Docker (MacOS)'
-        if: ${{ matrix.platform == 'macos-13-large' }}
-        uses: douglascamata/setup-docker-macos-action@v1-alpha
+          brew install protobuf tree
       - name: 'Setup Rust'
         run: |
           curl -sSf https://sh.rustup.rs | sh -s -- -y
@@ -104,6 +151,7 @@ jobs:
       - name: 'Run Rust tests'
         shell: bash
         run: |
+          mv ./wasm-components ./.wasm_cache
           mkdir -p test-results
 
           echo "${{ matrix.platform }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 cache
 deps
 typescript/packages/planning-server/.env
+.wasm_cache

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,6 +36,20 @@ Once all dependencies are set up, run:
 cargo test
 ```
 
+## Optimizations
+
+### Wasm Components
+
+Currently, when you build some crates (like `common-runtime`), the `build.rs`
+will invoke a Docker build step to produce some Wasm Component artifacts. This
+can be quite slow in some environments.
+
+If you can produce any needed Wasm artifacts as a pre-build step (either
+compiling locally or perhaps pulling the artifacts from a cache), you can place
+them in a `.wasm_cache` folder in the root of this workspace.
+
+For an example of this, refer to the [`rust.yaml` Github Workflow](./.github/workflows/rust.yaml)
+
 [cargo]: https://doc.rust-lang.org/cargo/getting-started/installation.html
 [binstall]: https://github.com/cargo-bins/cargo-binstall
 [node.js]: https://nodejs.org/en/learn/getting-started/how-to-install-nodejs

--- a/rust/common-runtime/build.rs
+++ b/rust/common-runtime/build.rs
@@ -1,3 +1,4 @@
+use std::fs::copy;
 use std::{path::PathBuf, process::Command};
 
 fn main() {
@@ -6,20 +7,35 @@ fn main() {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
     println!("cargo::rustc-env=COMMON_JAVASCRIPT_INTERPRETER_WASM_PATH={}/common_javascript_interpreter.wasm", out_dir.display());
-    println!(
-        "cargo::rerun-if-changed={}/rust/common-javascript-interpreter",
-        project_root_dir.display()
-    );
-    println!(
-        "cargo::rerun-if-changed={}/build/components",
-        project_root_dir.display()
-    );
 
-    if !Command::new("./scripts/generate-artifacts.sh")
-        .status()
-        .unwrap()
-        .success()
-    {
-        println!("Failed to generate required artifacts");
+    let cached_artifact_file = project_root_dir
+        .join(".wasm_cache")
+        .join("common_javascript_interpreter.wasm");
+
+    if cached_artifact_file.is_file() {
+        println!("cargo::rerun-if-changed={}", cached_artifact_file.display());
+
+        copy(
+            cached_artifact_file,
+            out_dir.join("common_javascript_interpreter.wasm"),
+        )
+        .unwrap();
+    } else {
+        println!(
+            "cargo::rerun-if-changed={}/rust/common-javascript-interpreter",
+            project_root_dir.display()
+        );
+        println!(
+            "cargo::rerun-if-changed={}/build/components",
+            project_root_dir.display()
+        );
+
+        if !Command::new("./scripts/generate-artifacts.sh")
+            .status()
+            .unwrap()
+            .success()
+        {
+            println!("Failed to generate required artifacts");
+        }
     }
 }


### PR DESCRIPTION
This change moves the Wasm Component build out into its own shared job in our Github Workflow. The resulting artifact is then uploaded and shared across all test builds. A counterpart change to the `common-runtime` `build.rs` checks for the downloaded artifact and then skips the Dockerized build step if it is found.