### PR TITLE
chore: Make `wasm32-unknown-unknown` build

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -6,6 +6,10 @@ on:
 
 name: 'Rust'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lints:
     name: 'Lints'
@@ -19,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - name: 'Install OS packages'
+      - name: 'Install OS packages (Ubuntu)'
         run: |
           sudo apt update && sudo apt upgrade -y
           sudo apt install -y protobuf-compiler libprotobuf-dev
@@ -53,6 +57,52 @@ jobs:
         run: cargo +${{matrix.toolchain}} component fmt --all -- --check
       - name: 'Run Linter'
         run: cargo +${{matrix.toolchain}} component clippy --all -- -D warnings
+
+  build-wasm32-unknown-unknown:
+    name: 'Build wasm32-unknown-unknown'
+    needs: ['lints']
+    runs-on: 'ubuntu-latest'
+    continue-on-error: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - name: 'Install OS packages (Ubuntu)'
+        run: |
+          sudo apt update && sudo apt upgrade -y
+          sudo apt install -y protobuf-compiler libprotobuf-dev
+      - name: 'Setup Rust'
+        run: |
+          curl -sSf https://sh.rustup.rs | sh -s -- -y
+          rustup toolchain install stable
+          rustup target add wasm32-unknown-unknown
+      - name: 'Setup Node/NPM'
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.4.4
+      - name: Install binaries from cargo
+        run: |
+          cargo binstall wit-deps-cli wasm-tools cargo-component --no-confirm --force
+      - name: 'Install NPM dependencies'
+        run: |
+          npm install -g @bytecodealliance/jco @bytecodealliance/componentize-js
+          cd typescript
+          npm ci
+      - name: 'Run wit-deps on Wasm Component projects'
+        run: |
+          # NOTE: cargo-component doesn't invoke build.rs as expected when
+          # performing checked format
+          cd ./rust/common-javascript-interpreter
+          RUST_LOG=trace wit-deps
+      - name: 'Generate bindings for Wasm Components'
+        run: |
+          # NOTE: cargo-component doesn't invoke build.rs as expected when
+          # performing checked format
+          cd ./rust/common-javascript-interpreter
+          cargo component check
+      - name: 'Build wasm32-unknown-unknown'
+        run: cargo build --target wasm32-unknown-unknown
 
   build-wasm-components:
     name: 'Build Wasm Components'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,6 @@ checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
- "axum-macros",
  "bytes",
  "futures-util",
  "http",
@@ -203,7 +202,6 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -238,18 +236,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -730,6 +716,7 @@ dependencies = [
  "boa_runtime",
  "common-test-fixtures",
  "common-wit",
+ "getrandom",
  "once_cell",
  "wit-bindgen-rt",
 ]
@@ -758,7 +745,6 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "axum",
  "blake3",
  "bytes",
  "common-builder",
@@ -767,12 +753,10 @@ dependencies = [
  "common-tracing",
  "common-wit",
  "criterion",
+ "getrandom",
  "http",
- "hyper-util",
  "mime_guess",
  "rand",
- "redb",
- "rust-embed",
  "serde",
  "serde_json",
  "sieve-cache",
@@ -786,7 +770,6 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "wit-parser 0.212.0",
 ]
 
 [[package]]
@@ -1593,8 +1576,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1674,12 +1659,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2316,23 +2295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
 
 [[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
-]
-
-[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac47baaef3631368888abc13a62cb6d42b88bfd5c3fc6f920a9cbe4d7d3ddc9d"
+checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2724,12 +2686,12 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04952a6dc0bf60a696e83fc8c58e912d4f6c1d06c6637db44c1cce9c6735c920"
+checksum = "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -2745,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5834058badd2cf6cfcd9c92998ceb2bab614f012cccf3728de3edf2c57b9132"
+checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -2758,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1964ef64b94480df8c92ae14e5764d470014ad951d2f99e5a6c0c7712710c"
+checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
 dependencies = [
  "prost",
 ]
@@ -3062,40 +3024,6 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rust-embed"
-version = "8.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
-dependencies = [
- "sha2",
- "walkdir",
 ]
 
 [[package]]
@@ -4277,9 +4205,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f738b6a169a29bca4e39656db89c44a08e09c5b700b896ee9e7459f0652e81dd"
+checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4307,9 +4235,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690943cc223adcdd67bb597a2e573ead1b88e999ba37528fe8e6356bf44b29b6"
+checksum = "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5050,7 +4978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
 dependencies = [
  "anyhow",
- "heck 0.4.1",
+ "heck",
  "indexmap 2.2.6",
  "wit-parser 0.209.1",
 ]
@@ -5137,7 +5065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557567f2793508760cd855f7659b7a0b9dc4dbc451f53f1415d6943a15311ade"
 dependencies = [
  "anyhow",
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ common-wit = { path = "./rust/common-wit" }
 criterion = { version = "0.5" }
 deno_emit = { version = "0.43" }
 deno_graph = { version = "0.79" }
+getrandom = { version = "0.2", features = ["js"] }
 http = { version = "1.1" }
 http-body-util = { version = "0.1" }
 hyper-util = { version = "0.1", features = ["client", "client-legacy"] }
@@ -44,6 +45,7 @@ lazy_static = { version = "1" }
 mime_guess = { version = "2" }
 once_cell = { version = "1" }
 prost = { version = "0.13" }
+quote = { version = "1" }
 rand = { version = "0.8" }
 redb = { version = "2" }
 reqwest = { version = "0.12", default-features = false  }
@@ -51,10 +53,11 @@ rust-embed = { version = "8.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 sieve-cache = { version = "0.2" }
+syn = { version = "2" }
 tempfile = { version = "3" }
 thiserror = { version = "1" }
-tonic = { version = "0.12" }
-tonic-build = { version = "0.12" }
+tonic = { version = "0.12", default-features = false }
+tonic-build = { version = "0.12", default-features = false, features = [ "prost" ] }
 tokio = { version = "1" }
 tower-http = { version = "0.5" }
 tracing = { version = "0.1" }

--- a/rust/common-builder/Cargo.toml
+++ b/rust/common-builder/Cargo.toml
@@ -5,9 +5,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[dependencies]
-common-wit = { workspace = true }
-
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
@@ -15,6 +13,7 @@ blake3 = { workspace = true }
 bytes = { workspace = true }
 common-protos = { workspace = true, features = ["builder"] }
 common-tracing = { workspace = true }
+common-wit = { workspace = true }
 deno_emit = { workspace = true }
 deno_graph = { workspace = true }
 mime_guess = { workspace = true }

--- a/rust/common-builder/src/bin/builder.rs
+++ b/rust/common-builder/src/bin/builder.rs
@@ -1,10 +1,22 @@
+#[cfg(not(target_arch = "wasm32"))]
 #[macro_use]
 extern crate tracing;
 
+#[cfg(not(target_arch = "wasm32"))]
 use common_builder::{serve, BuilderError};
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::net::SocketAddr;
+
+#[cfg(not(target_arch = "wasm32"))]
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
+#[cfg(target_arch = "wasm32")]
+pub fn main() {
+    unimplemented!("Binary not supported for wasm32")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 pub async fn main() -> Result<(), BuilderError> {
     let subscriber = FmtSubscriber::builder()

--- a/rust/common-builder/src/lib.rs
+++ b/rust/common-builder/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_arch = "wasm32"))]
 #![warn(missing_docs)]
 //! Utilities for compiling/bundling JavaScript into
 //! a single source.

--- a/rust/common-builder/tests/server.rs
+++ b/rust/common-builder/tests/server.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use common_builder::serve;
 use common_protos::{
     builder::{

--- a/rust/common-javascript-interpreter/Cargo.toml
+++ b/rust/common-javascript-interpreter/Cargo.toml
@@ -11,6 +11,9 @@ boa_runtime = { workspace = true }
 once_cell = { workspace = true }
 wit-bindgen-rt = { workspace = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true }
+
 [build-dependencies]
 common-wit = { workspace = true }
 

--- a/rust/common-macros/Cargo.toml
+++ b/rust/common-macros/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 proc-macro = true
 
 [dependencies]
-quote = "1.0.36"
-syn = "2.0.71"
+quote = { workspace = true }
+syn = { workspace = true }
 
 [features]
 tracing = []

--- a/rust/common-protos/Cargo.toml
+++ b/rust/common-protos/Cargo.toml
@@ -5,14 +5,19 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[dependencies]
-tonic = { workspace = true }
-prost = { workspace = true }
-
-[build-dependencies]
-tonic-build = { workspace = true }
-
 [features]
 default = ["runtime", "builder"]
 runtime = []
 builder = []
+
+[dependencies]
+prost = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tonic = { workspace = true, features = ["codegen", "prost", "transport"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tonic = { workspace = true, default-features = false, features = ["codegen", "prost"] }
+
+[build-dependencies]
+tonic-build = { workspace = true, default-features = false, features = ["prost", "transport"] }

--- a/rust/common-protos/build.rs
+++ b/rust/common-protos/build.rs
@@ -27,7 +27,10 @@ fn main() {
         sources.push(BUILDER_SOURCE);
     }
 
+    let target = env::var("TARGET").unwrap();
+
     tonic_build::configure()
+        .build_transport(target != "wasm32-unknown-unknown")
         .file_descriptor_set_path(out_dir.join("protos_descriptor.bin"))
         // Will always rebuild unless `emit_rerun_if_changed` is false.
         .emit_rerun_if_changed(false)

--- a/rust/common-runtime/Cargo.toml
+++ b/rust/common-runtime/Cargo.toml
@@ -4,38 +4,37 @@ description = "A Common runtime"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 async-stream = { workspace = true }
-axum = { workspace = true, features = ["multipart", "macros"] }
 blake3 = { workspace = true }
 bytes = { workspace = true }
-common-protos = { workspace = true, features = ["runtime"] }
+common-protos = { workspace = true, features = ["runtime", "builder"] }
 common-tracing = { workspace = true }
 common-wit = { workspace = true }
 http = { workspace = true }
-hyper-util = { workspace = true }
 mime_guess = { workspace = true }
 rand = { workspace = true }
-redb = { workspace = true }
-rust-embed = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sieve-cache = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "process", "fs"] }
-tonic = { workspace = true }
-tower-http = { workspace = true, features = ["cors"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "process", "fs"] }
+tonic = { workspace = true, features = ["codegen", "prost", "transport"] }
+tower-http = { workspace = true, features = ["cors"] }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
-wit-parser = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["js"]}
+tokio = { workspace = true, features = ["rt"] }
+tonic = { workspace = true, features = ["codegen", "prost"] }
 
 [build-dependencies]
 tempfile = { workspace = true }
@@ -43,8 +42,11 @@ tempfile = { workspace = true }
 [dev-dependencies]
 common-builder = { workspace = true }
 common-test-fixtures = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]
 name = "runtime_bench"
 harness = false
+required-features = ["bench"]

--- a/rust/common-runtime/benches/runtime_bench.rs
+++ b/rust/common-runtime/benches/runtime_bench.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use anyhow::Result;
 use common_builder::{serve as serve_builder, BuilderError};
 use common_runtime::{

--- a/rust/common-runtime/src/bin/runtime.rs
+++ b/rust/common-runtime/src/bin/runtime.rs
@@ -1,13 +1,19 @@
+#[cfg(not(target_arch = "wasm32"))]
 #[macro_use]
 extern crate tracing;
 
-use std::net::SocketAddr;
+#[cfg(target_arch = "wasm32")]
+pub fn main() {
+    unimplemented!("Binary not supported for wasm32")
+}
 
-use common_runtime::{serve, CommonRuntimeError};
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
-
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
-pub async fn main() -> Result<(), CommonRuntimeError> {
+pub async fn main() -> Result<(), common_runtime::CommonRuntimeError> {
+    use common_runtime::serve;
+    use std::net::SocketAddr;
+    use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
         .finish();

--- a/rust/common-runtime/src/error.rs
+++ b/rust/common-runtime/src/error.rs
@@ -52,6 +52,7 @@ pub enum CommonRuntimeError {
     InvalidInstantiationParameters(String),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl From<tonic::transport::Error> for CommonRuntimeError {
     fn from(value: tonic::transport::Error) -> Self {
         CommonRuntimeError::InternalError(format!("{value}"))

--- a/rust/common-runtime/src/lib.rs
+++ b/rust/common-runtime/src/lib.rs
@@ -26,7 +26,9 @@ pub use value::*;
 mod module;
 pub use module::*;
 
+#[cfg(not(target_arch = "wasm32"))]
 mod serve;
+#[cfg(not(target_arch = "wasm32"))]
 pub use serve::*;
 
 mod io;

--- a/rust/common-runtime/src/sandbox/browser/compile.rs
+++ b/rust/common-runtime/src/sandbox/browser/compile.rs
@@ -1,0 +1,109 @@
+// REASON: Docs will be added when stubs are filled out
+#![allow(missing_docs)]
+use async_trait::async_trait;
+use std::marker::PhantomData;
+
+use crate::{
+    InputOutput, ModuleDefinition, ModuleInstance, ModulePreparer, PreparedModule, ToWasmComponent,
+};
+
+#[derive(Clone)]
+pub struct CompiledModuleInstance<Io>
+where
+    Io: InputOutput,
+{
+    _marker: PhantomData<Io>,
+}
+
+impl<Io> CompiledModuleInstance<Io>
+where
+    Io: InputOutput,
+{
+    pub fn new() -> Self {
+        CompiledModuleInstance {
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Io> ModuleInstance for CompiledModuleInstance<Io>
+where
+    Io: InputOutput,
+{
+    type InputOutput = Io;
+
+    fn id(&self) -> &crate::ModuleInstanceId {
+        todo!()
+    }
+
+    async fn run(
+        &self,
+        _io: Self::InputOutput,
+    ) -> Result<Self::InputOutput, crate::CommonRuntimeError> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+pub struct CompilerPreparedModule<Io>
+where
+    Io: InputOutput,
+{
+    _marker: PhantomData<Io>,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Io> PreparedModule for CompilerPreparedModule<Io>
+where
+    Io: InputOutput,
+{
+    type InputOutput = Io;
+
+    type ModuleInstance = CompiledModuleInstance<Io>;
+
+    async fn instantiate(
+        &self,
+        _io: Self::InputOutput,
+    ) -> Result<Self::ModuleInstance, crate::CommonRuntimeError> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+pub struct BrowserCompiler<Io>
+where
+    Io: InputOutput,
+{
+    _marker: PhantomData<Io>,
+}
+
+impl<Io> BrowserCompiler<Io>
+where
+    Io: InputOutput,
+{
+    pub fn new() -> Self {
+        BrowserCompiler {
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Module, Io> ModulePreparer<Module> for BrowserCompiler<Io>
+where
+    Module: ModuleDefinition + ToWasmComponent + 'static,
+    Io: InputOutput,
+{
+    type PreparedModule = CompilerPreparedModule<Io>;
+
+    async fn prepare(
+        &mut self,
+        _module: Module,
+    ) -> Result<Self::PreparedModule, crate::CommonRuntimeError> {
+        todo!()
+    }
+}

--- a/rust/common-runtime/src/sandbox/browser/interpret.rs
+++ b/rust/common-runtime/src/sandbox/browser/interpret.rs
@@ -1,0 +1,122 @@
+// REASON: Docs will be added when stubs are filled out
+#![allow(missing_docs)]
+
+use async_trait::async_trait;
+use std::marker::PhantomData;
+
+use crate::{
+    InputOutput, ModuleDefinition, ModuleInstance, ModulePreparer, PreparedModule, ToModuleSources,
+    ToWasmComponent,
+};
+
+#[derive(Clone)]
+pub struct InterpretedModuleInstance<Io>
+where
+    Io: InputOutput,
+{
+    _marker: PhantomData<Io>,
+}
+
+impl<Io> InterpretedModuleInstance<Io>
+where
+    Io: InputOutput,
+{
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Io> ModuleInstance for InterpretedModuleInstance<Io>
+where
+    Io: InputOutput,
+{
+    type InputOutput = Io;
+
+    fn id(&self) -> &crate::ModuleInstanceId {
+        todo!()
+    }
+
+    async fn run(
+        &self,
+        _io: Self::InputOutput,
+    ) -> Result<Self::InputOutput, crate::CommonRuntimeError> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+pub struct InterpreterPreparedModule<Io>
+where
+    Io: InputOutput,
+{
+    _marker: PhantomData<Io>,
+}
+
+impl<Io> InterpreterPreparedModule<Io>
+where
+    Io: InputOutput,
+{
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Io> PreparedModule for InterpreterPreparedModule<Io>
+where
+    Io: InputOutput,
+{
+    type InputOutput = Io;
+
+    type ModuleInstance = InterpretedModuleInstance<Io>;
+
+    async fn instantiate(
+        &self,
+        _io: Self::InputOutput,
+    ) -> Result<Self::ModuleInstance, crate::CommonRuntimeError> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+pub struct BrowserInterpreter<Io>
+where
+    Io: InputOutput,
+{
+    _marker: PhantomData<Io>,
+}
+
+impl<Io> BrowserInterpreter<Io>
+where
+    Io: InputOutput,
+{
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl<Module, Io> ModulePreparer<Module> for BrowserInterpreter<Io>
+where
+    Module: ModuleDefinition + ToModuleSources + ToWasmComponent + 'static,
+    Io: InputOutput,
+{
+    type PreparedModule = InterpreterPreparedModule<Io>;
+
+    async fn prepare(
+        &mut self,
+        _module: Module,
+    ) -> Result<Self::PreparedModule, crate::CommonRuntimeError> {
+        todo!()
+    }
+}

--- a/rust/common-runtime/src/sandbox/browser/mod.rs
+++ b/rust/common-runtime/src/sandbox/browser/mod.rs
@@ -1,0 +1,8 @@
+//! This module contains implementations of sandboxing based on the Core Wasm
+//! APIs that broadly available in web browsers.
+
+mod compile;
+pub use compile::*;
+
+mod interpret;
+pub use interpret::*;

--- a/rust/common-runtime/src/sandbox/mod.rs
+++ b/rust/common-runtime/src/sandbox/mod.rs
@@ -1,1 +1,5 @@
+#[cfg(not(target_arch = "wasm32"))]
 pub mod wasmtime;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub mod browser;

--- a/rust/common-runtime/src/sandbox/wasmtime/compile/bindings.rs
+++ b/rust/common-runtime/src/sandbox/wasmtime/compile/bindings.rs
@@ -2,7 +2,7 @@
 
 use crate::wasmtime::bindings::common_module::*;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi::{WasiCtx, WasiView};
 

--- a/rust/common-runtime/src/sandbox/wasmtime/interpret/bindings.rs
+++ b/rust/common-runtime/src/sandbox/wasmtime/interpret/bindings.rs
@@ -1,6 +1,6 @@
 use crate::wasmtime::bindings::common_script::*;
 
-use axum::async_trait;
+use async_trait::async_trait;
 use wasmtime::component::{Resource, ResourceTable};
 
 // NOTE: This module comes from wasmtime::component::bindgen

--- a/rust/common-runtime/tests/compiled_modules.rs
+++ b/rust/common-runtime/tests/compiled_modules.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use anyhow::Result;
 use common_builder::serve as serve_builder;
 use common_protos::{builder, common, runtime};

--- a/rust/common-runtime/tests/interpreted_modules.rs
+++ b/rust/common-runtime/tests/interpreted_modules.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_arch = "wasm32"))]
+
 use anyhow::Result;
 use common_builder::serve as serve_builder;
 

--- a/rust/common-test-fixtures/Cargo.toml
+++ b/rust/common-test-fixtures/Cargo.toml
@@ -7,11 +7,15 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum = { workspace = true }
 tokio = { workspace = true, features = ["process", "fs", "macros"] }
 tower-http = { workspace = true, features = ["fs"] }
-tracing = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 reqwest = { workspace = true }

--- a/rust/common-test-fixtures/src/lib.rs
+++ b/rust/common-test-fixtures/src/lib.rs
@@ -1,94 +1,11 @@
 #![warn(missing_docs)]
-//! A static server for serving various types of ES modules
-//! for testing.
 
-use anyhow::Result;
-use axum::Router;
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    path::{Path, PathBuf},
-};
-use tokio::{net::TcpListener, task::JoinHandle};
-use tower_http::services::ServeDir;
+//! This crate contains test fixtures and shared helper code that is used across
+//! the common-* constellation of crates
+
+#[cfg(not(target_arch = "wasm32"))]
+mod server;
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;
 
 pub mod sources;
-
-/// Manages a static server for use in builders and bundlers,
-/// serving various types of ES modules.
-pub struct EsmTestServer {
-    handle: Option<JoinHandle<()>>,
-    dir: PathBuf,
-}
-
-impl EsmTestServer {
-    /// Create a new [ESMTestServer], serving the
-    /// `dir` directory at the host HTTP root "/".
-    pub fn new<P: AsRef<Path>>(dir: P) -> Self {
-        Self {
-            handle: None,
-            dir: dir.as_ref().into(),
-        }
-    }
-
-    /// Start the static server on `port`. Upon success, a
-    /// [SocketAddr] is returned of the static server.
-    pub async fn start_with_port(&mut self, port: u16) -> Result<SocketAddr> {
-        let listener = TcpListener::bind((Ipv4Addr::new(127, 0, 0, 1), port)).await?;
-        let addr = listener.local_addr()?;
-        let serve_dir = ServeDir::new(&self.dir);
-        self.handle = Some(tokio::spawn(async {
-            let app = Router::new().nest_service("/", serve_dir);
-            axum::serve(listener, app.into_make_service())
-                .await
-                .unwrap();
-        }));
-        Ok(addr)
-    }
-
-    /// Start the static server, using an available port implicitly.
-    /// See [ESMTestServer::start_with_port] for more details.
-    pub async fn start(&mut self) -> Result<SocketAddr> {
-        self.start_with_port(0).await
-    }
-
-    /// Terminates the static server. Called automatically when
-    /// [ESMTestServer] is dropped.
-    pub fn stop(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
-        }
-    }
-}
-
-impl Default for EsmTestServer {
-    fn default() -> Self {
-        // The crate root is used as PWD when running
-        // cargo tests, so in most cases this should
-        // serve as a good default. TBD what ways
-        // tests can run where this fails.
-        Self::new("../common-test-fixtures/fixtures")
-    }
-}
-
-impl Drop for EsmTestServer {
-    fn drop(&mut self) {
-        self.stop()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use tokio::fs;
-
-    #[tokio::test]
-    async fn it_serves_content_from_static_dir() -> Result<()> {
-        let mut server = EsmTestServer::default();
-        let addr = server.start().await?;
-        let url = format!("http://{}/math/index.js", addr);
-        let module = reqwest::get(url).await?.text().await?;
-
-        assert_eq!(module, fs::read_to_string("fixtures/math/index.js").await?);
-        Ok(())
-    }
-}

--- a/rust/common-test-fixtures/src/server.rs
+++ b/rust/common-test-fixtures/src/server.rs
@@ -1,0 +1,91 @@
+//! A static server for serving various types of ES modules
+//! for testing.
+
+use anyhow::Result;
+use axum::Router;
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    path::{Path, PathBuf},
+};
+use tokio::{net::TcpListener, task::JoinHandle};
+use tower_http::services::ServeDir;
+
+/// Manages a static server for use in builders and bundlers,
+/// serving various types of ES modules.
+pub struct EsmTestServer {
+    handle: Option<JoinHandle<()>>,
+    dir: PathBuf,
+}
+
+impl EsmTestServer {
+    /// Create a new [ESMTestServer], serving the
+    /// `dir` directory at the host HTTP root "/".
+    pub fn new<P: AsRef<Path>>(dir: P) -> Self {
+        Self {
+            handle: None,
+            dir: dir.as_ref().into(),
+        }
+    }
+
+    /// Start the static server on `port`. Upon success, a
+    /// [SocketAddr] is returned of the static server.
+    pub async fn start_with_port(&mut self, port: u16) -> Result<SocketAddr> {
+        let listener = TcpListener::bind((Ipv4Addr::new(127, 0, 0, 1), port)).await?;
+        let addr = listener.local_addr()?;
+        let serve_dir = ServeDir::new(&self.dir);
+        self.handle = Some(tokio::spawn(async {
+            let app = Router::new().nest_service("/", serve_dir);
+            axum::serve(listener, app.into_make_service())
+                .await
+                .unwrap();
+        }));
+        Ok(addr)
+    }
+
+    /// Start the static server, using an available port implicitly.
+    /// See [ESMTestServer::start_with_port] for more details.
+    pub async fn start(&mut self) -> Result<SocketAddr> {
+        self.start_with_port(0).await
+    }
+
+    /// Terminates the static server. Called automatically when
+    /// [ESMTestServer] is dropped.
+    pub fn stop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+impl Default for EsmTestServer {
+    fn default() -> Self {
+        // The crate root is used as PWD when running
+        // cargo tests, so in most cases this should
+        // serve as a good default. TBD what ways
+        // tests can run where this fails.
+        Self::new("../common-test-fixtures/fixtures")
+    }
+}
+
+impl Drop for EsmTestServer {
+    fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use tokio::fs;
+
+    #[tokio::test]
+    async fn it_serves_content_from_static_dir() -> Result<()> {
+        let mut server = EsmTestServer::default();
+        let addr = server.start().await?;
+        let url = format!("http://{}/math/index.js", addr);
+        let module = reqwest::get(url).await?.text().await?;
+
+        assert_eq!(module, fs::read_to_string("fixtures/math/index.js").await?);
+        Ok(())
+    }
+}


### PR DESCRIPTION
This  makes our workspace build under a `wasm32-unknown-unknown` target. The Wasm sandbox implementation for web browsers has been included but stubbed out. This was necessary to avoid conditionally compiling-out most of the Runtime to make `wasm32-unknown-unknown` build.

I want to propose that we land this change (to keep it small) and then follow it up with additional changes to fill out / document the stubs.