### PR TITLE
fix: resolve typo common-javasript-interpreter -> common-javascript-interpreter

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -47,12 +47,10 @@ jobs:
           npm install -g @bytecodealliance/jco @bytecodealliance/componentize-js
           cd typescript
           npm ci
-#      - name: 'Run wit-deps on Wasm Component projects'
-#        run: |
-#          # NOTE: cargo-component doesn't invoke build.rs as expected when
-#          # performing checked format
-#          cd ./rust/common-javascript-interpreter
-#          RUST_LOG=trace wit-deps
+      - name: 'Run wit-deps on Wasm Component projects'
+        run: |
+          cd ./rust/common-javascript-interpreter
+          cargo component check
       - name: 'Check Format'
         run: cargo +${{matrix.toolchain}} component fmt --all -- --check
       - name: 'Run Linter'

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -47,12 +47,12 @@ jobs:
           npm install -g @bytecodealliance/jco @bytecodealliance/componentize-js
           cd typescript
           npm ci
-      - name: 'Run wit-deps on Wasm Component projects'
-        run: |
-          # NOTE: cargo-component doesn't invoke build.rs as expected when
-          # performing checked format
-          cd ./rust/common-javascript-interpreter
-          RUST_LOG=trace wit-deps
+#      - name: 'Run wit-deps on Wasm Component projects'
+#        run: |
+#          # NOTE: cargo-component doesn't invoke build.rs as expected when
+#          # performing checked format
+#          cd ./rust/common-javascript-interpreter
+#          RUST_LOG=trace wit-deps
       - name: 'Check Format'
         run: cargo +${{matrix.toolchain}} component fmt --all -- --check
       - name: 'Run Linter'
@@ -89,18 +89,18 @@ jobs:
           npm install -g @bytecodealliance/jco @bytecodealliance/componentize-js
           cd typescript
           npm ci
-      - name: 'Run wit-deps on Wasm Component projects'
-        run: |
-          # NOTE: cargo-component doesn't invoke build.rs as expected when
-          # performing checked format
-          cd ./rust/common-javascript-interpreter
-          RUST_LOG=trace wit-deps
-      - name: 'Generate bindings for Wasm Components'
-        run: |
-          # NOTE: cargo-component doesn't invoke build.rs as expected when
-          # performing checked format
-          cd ./rust/common-javascript-interpreter
-          cargo component check
+#      - name: 'Run wit-deps on Wasm Component projects'
+#        run: |
+#          # NOTE: cargo-component doesn't invoke build.rs as expected when
+#          # performing checked format
+#          cd ./rust/common-javascript-interpreter
+#          RUST_LOG=trace wit-deps
+#      - name: 'Generate bindings for Wasm Components'
+#        run: |
+#          # NOTE: cargo-component doesn't invoke build.rs as expected when
+#          # performing checked format
+#          cd ./rust/common-javascript-interpreter
+#          cargo component check
       - name: 'Build wasm32-unknown-unknown'
         run: cargo build -vv --target wasm32-unknown-unknown
 
@@ -133,12 +133,12 @@ jobs:
           npm install -g @bytecodealliance/jco @bytecodealliance/componentize-js@0.9.0
           cd typescript
           npm ci
-      - name: 'Run wit-deps on Wasm Component projects'
-        run: |
-          # NOTE: cargo-component doesn't invoke build.rs as expected when
-          # performing checked format
-          cd ./rust/common-javascript-interpreter
-          RUST_LOG=trace wit-deps
+#      - name: 'Run wit-deps on Wasm Component projects'
+#        run: |
+#          # NOTE: cargo-component doesn't invoke build.rs as expected when
+#          # performing checked format
+#          cd ./rust/common-javascript-interpreter
+#          RUST_LOG=trace wit-deps
       - name: 'Build Rust-based Wasm Components'
         shell: bash
         run: |
@@ -192,12 +192,12 @@ jobs:
           npm install -g @bytecodealliance/jco @bytecodealliance/componentize-js@0.9.0
           cd typescript
           npm ci
-      - name: 'Run wit-deps on Wasm Component projects'
-        run: |
-          # NOTE: cargo-component doesn't invoke build.rs as expected when
-          # performing checked format
-          cd ./rust/common-javascript-interpreter
-          RUST_LOG=trace wit-deps
+#      - name: 'Run wit-deps on Wasm Component projects'
+#        run: |
+#          # NOTE: cargo-component doesn't invoke build.rs as expected when
+#          # performing checked format
+#          cd ./rust/common-javascript-interpreter
+#          RUST_LOG=trace wit-deps
       - name: 'Run Rust tests'
         shell: bash
         run: |

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -102,7 +102,7 @@ jobs:
           cd ./rust/common-javascript-interpreter
           cargo component check
       - name: 'Build wasm32-unknown-unknown'
-        run: cargo build --target wasm32-unknown-unknown
+        run: cargo build -vv --target wasm32-unknown-unknown
 
   build-wasm-components:
     name: 'Build Wasm Components'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ boa_runtime = { version = "0.19" }
 bytes = { version = "1" }
 clap = { version = "4.5" }
 common-builder = { path = "./rust/common-builder" }
-common-javascript-interpreter = { path = "./rust/common-javasript-interpreter" }
+common-javascript-interpreter = { path = "./rust/common-javascript-interpreter" }
 common-macros = { path = "./rust/common-macros" }
 common-protos = { path = "./rust/common-protos", default-features = false }
 common-runtime = { path = "./rust/common-runtime" }

--- a/rust/common-wit/build.rs
+++ b/rust/common-wit/build.rs
@@ -9,6 +9,17 @@ const TYPESCRIPT_SOURCE_DEPENDENCIES: &[&str] = &[
 ];
 
 fn main() {
+    // Clean node_modules directory to avoid file conflicts
+    if !Command::new("rm")
+        .arg("-rf")
+        .arg("../../typescript/node_modules")
+        .status()
+        .unwrap()
+        .success()
+    {
+        panic!("Failed to clean node_modules directory");
+    }
+
     if !Command::new("npm")
         .arg("ci")
         .current_dir("../../typescript")

--- a/rust/common-wit/build.rs
+++ b/rust/common-wit/build.rs
@@ -20,6 +20,7 @@ fn main() {
         panic!("Failed to clean node_modules directory");
     }
 
+    // Run npm ci
     if !Command::new("npm")
         .arg("ci")
         .current_dir("../../typescript")
@@ -30,6 +31,7 @@ fn main() {
         panic!("Failed to run npm install");
     }
 
+    // Run npm build
     if !Command::new("npm")
         .arg("run")
         .arg("build")
@@ -41,6 +43,7 @@ fn main() {
         panic!("Failed to run npm build");
     }
 
+    // Track changes in TypeScript source dependencies
     for fragment in TYPESCRIPT_SOURCE_DEPENDENCIES.iter() {
         println!("cargo:rerun-if-changed=../../typescript/{fragment}");
     }

--- a/typescript/common/script/package.json
+++ b/typescript/common/script/package.json
@@ -16,8 +16,7 @@
     "clean": "wireit",
     "prepare": "wireit",
     "update:wit": "wireit",
-    "lint:wit": "wireit",
-    "build:wit:inline": "wireit"
+    "lint:wit": "wireit"
   },
   "repository": {
     "type": "git",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -12,6 +12,8 @@
         "./common/*"
       ],
       "devDependencies": {
+        "@types/node": "^20.14.11",
+        "typescript": "^5.5.4",
         "wireit": "^0.14.5"
       }
     },
@@ -46,6 +48,7 @@
       }
     },
     "common/script": {
+      "name": "@commontools/script",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "devDependencies": {
@@ -185,6 +188,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/acorn": {
@@ -871,10 +884,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -883,11 +897,23 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wireit": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.5.tgz",
       "integrity": "sha512-K4ka9YBpSyD6pmFZYTJd4VpPsAiPT6j/fOtLzYgnKWlPIMM7lAZjQQ30H7urO+Lqx1Wvrw88tQHBz4njy+lglg==",
       "dev": true,
+      "license": "Apache-2.0",
+      "workspaces": [
+        "vscode-extension",
+        "website"
+      ],
       "dependencies": {
         "brace-expansion": "^4.0.0",
         "chokidar": "^3.5.3",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,6 +22,8 @@
   },
   "homepage": "https://github.com/commontoolsinc/labs#readme",
   "devDependencies": {
+    "@types/node": "^20.14.11",
+    "typescript": "^5.5.4",
     "wireit": "^0.14.5"
   },
   "wireit": {
@@ -41,6 +43,5 @@
         "./common/script:clean"
       ]
     }
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
Fix a typo in the common javascript interpreter path in root Cargo.toml

@cdata I am wondering if this might be the reason for this [comment](https://github.com/commontoolsinc/system/blob/main/.github/workflows/rust.yaml#L52). `build.rs` seems to invoke locally now when I run `cargo component check`.

```
        run: |
          # NOTE: cargo-component doesn't invoke build.rs as expected when
          # performing checked format
          cd ./rust/common-javascript-interpreter
          RUST_LOG=trace wit-deps
```