### PR TITLE
feat: Add runtime examples featuring a CLI module evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-tools"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "common-builder",
+ "common-protos",
+ "common-runtime",
+ "http",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "common-tracing"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "rust/common-protos",
   "rust/common-runtime",
   "rust/common-test-fixtures",
+  "rust/common-tools",
   "rust/common-tracing",
   "rust/common-wit",
 ]

--- a/rust/common-javascript-interpreter/src/module.rs
+++ b/rust/common-javascript-interpreter/src/module.rs
@@ -161,8 +161,12 @@ impl Module {
                         context.run_jobs();
 
                         match module_evaluates.state() {
-                            PromiseState::Fulfilled(_) => println!("Module evaluated"),
-                            PromiseState::Pending => println!("Module didn't evaluate!"),
+                            PromiseState::Fulfilled(_) => {
+                                println!("Module evaluated")
+                            }
+                            PromiseState::Pending => {
+                                println!("Module didn't evaluate!")
+                            }
                             PromiseState::Rejected(error) => {
                                 println!("Module error: {}", error.display())
                             }

--- a/rust/common-runtime/src/value.rs
+++ b/rust/common-runtime/src/value.rs
@@ -54,6 +54,21 @@ impl TryFrom<common::Value> for Value {
     }
 }
 
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Value::String(v) => v.to_string(),
+                Value::Boolean(v) => v.to_string(),
+                Value::Number(v) => v.to_string(),
+                Value::Buffer(v) => format!("Buffer<{}b>", v.len()),
+            }
+        )
+    }
+}
+
 impl From<Value> for common::Value {
     fn from(value: Value) -> Self {
         common::Value {

--- a/rust/common-tools/Cargo.toml
+++ b/rust/common-tools/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "common-tools"
+description = "CLI tools for Common Runtime"
+version = "0.1.0"
+edition = "2021"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+common-builder = { workspace = true }
+common-protos = { workspace = true, features = ["runtime", "builder"] }
+common-runtime = { workspace = true }
+http = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "process", "fs"] }
+tonic = { workspace = true, features = ["channel"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/rust/common-tools/README.md
+++ b/rust/common-tools/README.md
@@ -1,0 +1,34 @@
+# common-tools
+
+CLI tools for the Common Runtime.
+
+## Usage
+
+First, start the runtime server. This will run until the process is terminated.
+
+```bash
+$ ct serve
+```
+
+Create a file "reflect.js" that passes its input named `"input"` to the output named `"output"`:
+
+```js
+import { read, write } from "common:io/state@0.0.1";
+
+export const run = () => {
+  const input = read("input");
+  const value = input?.deref().val;
+
+  write("output", {
+    tag: "string",
+    val: value,
+  });
+};
+```
+
+Execute the module passing stdin to `"input"`, reflecting to `"output"`, to stdout:
+
+```bash
+$ printf "Hello!" | ct run reflect.js -i
+Hello!
+```

--- a/rust/common-tools/src/bin/ct.rs
+++ b/rust/common-tools/src/bin/ct.rs
@@ -1,0 +1,18 @@
+#[cfg(target_arch = "wasm32")]
+pub fn main() {
+    unimplemented!("Binary not supported for wasm32")
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    use clap::Parser;
+    use common_tools::{exec_command, Cli};
+    use tracing_subscriber::{EnvFilter, FmtSubscriber};
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to configure tracing");
+
+    exec_command(Cli::parse()).await
+}

--- a/rust/common-tools/src/cli.rs
+++ b/rust/common-tools/src/cli.rs
@@ -1,0 +1,37 @@
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+/// CLI struct implementing [clap::Parser].
+#[derive(Parser)]
+#[command(version, about="Common Runtime Tools", long_about = None)]
+#[command(propagate_version = true)]
+pub struct Cli {
+    /// Command to execute.
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// CLI subcommands implementing [clap::Subcommand].
+#[derive(Subcommand)]
+pub enum Command {
+    /// Executes a module.
+    Run {
+        /// Path to module file to execute.
+        module_path: PathBuf,
+
+        /// Connect to runtime server on provided port.
+        #[arg(short, long, default_value_t = 8081)]
+        port: u16,
+
+        /// Use input from stdin as "input" to module.
+        #[arg(short = 'i', long)]
+        stdin: bool,
+    },
+
+    /// Start the necessary runtime and build server.
+    Serve {
+        /// Runtime server listens on provided port.
+        #[arg(short, long, default_value_t = 8081)]
+        port: u16,
+    },
+}

--- a/rust/common-tools/src/commands.rs
+++ b/rust/common-tools/src/commands.rs
@@ -1,0 +1,152 @@
+use crate::cli::Cli;
+use anyhow::{anyhow, Result};
+use common_protos::{
+    common,
+    runtime::{self, runtime_client::RuntimeClient},
+};
+use common_runtime::Value;
+use std::{
+    io::{stdin, Read},
+    path::{Path, PathBuf},
+};
+
+/// Entry point for CLI tool, taking a parsed [Cli] object.
+pub async fn exec_command(cli: Cli) -> Result<()> {
+    use crate::cli::Command::*;
+
+    match cli.command {
+        Run {
+            module_path,
+            port,
+            stdin,
+        } => run(module_path, port, stdin).await,
+        Serve { port } => serve(port).await,
+    }
+}
+
+/// Connect to runtime listening on `port`, executing
+/// module found at `module_path`.
+async fn run(module_path: PathBuf, port: u16, use_stdin: bool) -> Result<()> {
+    let mut runtime_client = RuntimeClient::connect(format!("http://127.0.0.1:{}", port))
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "Could not connect to runtime. Is `ct serve` running on port {}?",
+                port
+            )
+        })?;
+
+    let module_str = module_from_path(&module_path).await?;
+    let input = {
+        if use_stdin {
+            let mut buffer = String::new();
+            stdin().read_to_string(&mut buffer)?;
+            Some(buffer)
+        } else {
+            None
+        }
+    };
+
+    let output = exec_module(&mut runtime_client, &module_str, input).await?;
+
+    if let Some(output) = output {
+        println!("{}", Value::try_from(output)?);
+    }
+    Ok(())
+}
+
+/// Return the module found at `path` as a [String],
+/// normalizing for CLI usage.
+async fn module_from_path<P: AsRef<Path>>(path: P) -> Result<String> {
+    let path_ref = path.as_ref();
+    let module_path = if path_ref.is_absolute() {
+        path_ref.canonicalize()?
+    } else {
+        std::env::current_dir()?.join(path_ref).canonicalize()?
+    };
+    tokio::fs::read_to_string(&module_path)
+        .await
+        .map_err(|_| anyhow!("Could not read module at {}.", module_path.display()))
+}
+
+/// Executes `module_str` with `runtime_client`.
+/// Modules currently must have an output named `"output"`,
+/// and an optional input named `"input"`.
+async fn exec_module(
+    runtime_client: &mut RuntimeClient<tonic::transport::channel::Channel>,
+    module_str: &str,
+    input: Option<String>,
+) -> Result<Option<common::Value>> {
+    let runtime::InstantiateModuleResponse { instance_id, .. } = runtime_client
+        .instantiate_module(runtime::InstantiateModuleRequest {
+            output_shape: [("output".into(), common::ValueKind::String.into())].into(),
+            default_input: [(
+                "input".into(),
+                common::Value {
+                    variant: Some(common::value::Variant::String("".into())),
+                },
+            )]
+            .into(),
+            module_reference: Some(
+                runtime::instantiate_module_request::ModuleReference::ModuleSource(
+                    common::ModuleSource {
+                        target: common::Target::CommonScript.into(),
+                        source_code: [(
+                            "module".into(),
+                            common::SourceCode {
+                                content_type: common::ContentType::JavaScript.into(),
+                                body: module_str.into(),
+                            },
+                        )]
+                        .into(),
+                    },
+                ),
+            ),
+        })
+        .await?
+        .into_inner();
+
+    let input_io = input.unwrap_or_default();
+    let runtime::RunModuleResponse { output } = runtime_client
+        .run_module(runtime::RunModuleRequest {
+            instance_id,
+            input: [(
+                "input".into(),
+                common::Value {
+                    variant: Some(common::value::Variant::String(input_io)),
+                },
+            )]
+            .into(),
+        })
+        .await?
+        .into_inner();
+
+    Ok(output.get("output").cloned())
+}
+
+/// Starts a [common_runtime] server listening on `runtime_port`,
+/// with a [common_builder] server.
+async fn serve(runtime_port: u16) -> Result<()> {
+    use common_builder::serve as serve_builder;
+    use common_runtime::serve as serve_runtime;
+    use http::Uri;
+    use std::net::SocketAddr;
+    use tokio::net::TcpListener;
+
+    let builder_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let builder_address: Uri = format!("http://{}", builder_listener.local_addr()?).parse()?;
+    let builder_task = tokio::task::spawn(serve_builder(builder_listener));
+
+    let runtime_address: SocketAddr = format!("0.0.0.0:{runtime_port}")
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Invalid port: {}", runtime_port))?;
+    let runtime_listener = TcpListener::bind(runtime_address).await?;
+    let runtime_task = tokio::task::spawn(serve_runtime(runtime_listener, Some(builder_address)));
+
+    tokio::select! {
+        _ = builder_task => {},
+        _ = runtime_task => {},
+    }
+
+    Ok(())
+}

--- a/rust/common-tools/src/lib.rs
+++ b/rust/common-tools/src/lib.rs
@@ -1,0 +1,12 @@
+#![warn(missing_docs)]
+
+//! CLI tools for the Common Runtime.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod cli;
+#[cfg(not(target_arch = "wasm32"))]
+mod commands;
+#[cfg(not(target_arch = "wasm32"))]
+pub use cli::*;
+#[cfg(not(target_arch = "wasm32"))]
+pub use commands::*;


### PR DESCRIPTION
* Introduce `common-tools` crate for CLI tooling
* See `rust/common-tools/README.md` for usage