### PR TITLE
feat: add interpreted modules to benchmark.

### DIFF
--- a/rust/common-runtime/Cargo.toml
+++ b/rust/common-runtime/Cargo.toml
@@ -50,4 +50,3 @@ criterion = { workspace = true, features = ["async_tokio"] }
 [[bench]]
 name = "runtime_bench"
 harness = false
-required-features = ["bench"]

--- a/rust/common-runtime/benches/runtime_bench.rs
+++ b/rust/common-runtime/benches/runtime_bench.rs
@@ -39,10 +39,10 @@ impl BenchModule {
     }
 
     /// Module definition for [BASIC_MODULE_JS].
-    pub fn new_basic_js_module() -> Self {
+    pub fn new_basic_js_module(target: Target) -> Self {
         Self {
             module_source: ModuleSource {
-                target: Target::CommonModule.into(),
+                target,
                 source_code: [(
                     "module".to_owned(),
                     SourceCode {
@@ -64,32 +64,46 @@ fn run_benchmark(c: &mut Criterion) {
         .build()
         .unwrap();
 
-    let (runtime, instance_id, _builder_task) = async_runtime.block_on(async {
+    let (runtime, module_id, script_id, _) = async_runtime.block_on(async {
         let (builder_address, builder_task) = init_build_server().await.unwrap();
         let mut runtime = Runtime::new().unwrap();
-        let (module, initial_io) =
-            BenchModule::new_basic_js_module().into_components(Some(builder_address.clone()));
-        let instance_id = runtime.compile(module, initial_io).await.unwrap();
+        let module_id = {
+            let (module, initial_io) = BenchModule::new_basic_js_module(Target::CommonModule)
+                .into_components(Some(builder_address.clone()));
+            runtime.compile(module, initial_io).await.unwrap()
+        };
+        let script_id = {
+            let (module, initial_io) = BenchModule::new_basic_js_module(Target::CommonScript)
+                .into_components(Some(builder_address.clone()));
+            runtime.interpret(module, initial_io).await.unwrap()
+        };
 
-        (runtime, instance_id, builder_task)
+        (runtime, module_id, script_id, builder_task)
     });
 
     let bench_input = {
         let input = [("foo".into(), Value::String("updated foo".into()))].into();
-        let output_shape = runtime.output_shape(&instance_id).unwrap().to_owned();
+        let output_shape = runtime.output_shape(&module_id).unwrap().to_owned();
         RuntimeIo::new(input, output_shape)
     };
 
-    c.bench_with_input(
+    let mut group = c.benchmark_group("run_benchmark");
+
+    group.bench_with_input(
         BenchmarkId::new("Runtime::run_module", ""),
-        &bench_input,
+        &bench_input.clone(),
         |b, runtime_io| {
-            b.to_async(&async_runtime).iter(|| {
-                // As RuntimeIo is owned, containing dynamic BTreeMaps,
-                // we can't avoid either construction or cloning, responsible
-                // for ~70us
-                runtime.run(&instance_id, runtime_io.to_owned())
-            })
+            b.to_async(&async_runtime)
+                .iter(|| runtime.run(&module_id, runtime_io.to_owned()))
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("Runtime::run_script", ""),
+        &bench_input.clone(),
+        |b, runtime_io| {
+            b.to_async(&async_runtime)
+                .iter(|| runtime.run(&script_id, runtime_io.to_owned()))
         },
     );
 }


### PR DESCRIPTION
Interpreter looks around ~3x slower than the compiled form, but still rather fast. There used to be significantly more overhead as well (where `run_module`'s ~10us time reflects `main`, but that wasn't the case in the non-gRPC change https://github.com/commontoolsinc/system/pull/31 which was about 30x slower than here.. suspicious!

```
run_benchmark/Runtime::run_module/
                        time:   [8.5212 µs 8.5669 µs 8.6148 µs]
                        change: [-24.382% -22.561% -20.679%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
run_benchmark/Runtime::run_script/
                        time:   [27.816 µs 28.252 µs 28.756 µs]
                        change: [-4.6431% -1.0289% +2.6974%] (p = 0.59 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
```