### PR TITLE
feat: Initial IFC integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-ifc"
+version = "0.1.0"
+dependencies = [
+ "common-macros",
+ "common-protos",
+ "common-tracing",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "common-javascript-interpreter"
 version = "0.1.0"
 dependencies = [
@@ -790,6 +801,7 @@ dependencies = [
 name = "common-macros"
 version = "0.1.0"
 dependencies = [
+ "common-ifc",
  "quote",
  "syn",
 ]
@@ -814,6 +826,8 @@ dependencies = [
  "bytes",
  "clap",
  "common-builder",
+ "common-ifc",
+ "common-macros",
  "common-protos",
  "common-test-fixtures",
  "common-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "rust/common-builder",
   "rust/common-javascript-interpreter",
+  "rust/common-ifc",
   "rust/common-macros",
   "rust/common-protos",
   "rust/common-runtime",
@@ -26,6 +27,7 @@ boa_runtime = { version = "0.19" }
 bytes = { version = "1" }
 clap = { version = "4.5" }
 common-builder = { path = "./rust/common-builder" }
+common-ifc = { path = "./rust/common-ifc" }
 common-javascript-interpreter = { path = "./rust/common-javasript-interpreter" }
 common-macros = { path = "./rust/common-macros" }
 common-protos = { path = "./rust/common-protos", default-features = false }

--- a/proto/common/common.proto
+++ b/proto/common/common.proto
@@ -19,6 +19,12 @@ enum ValueKind {
   BUFFER = 3;
 }
 
+message LabeledData {
+  Value value = 1;
+  string confidentiality = 2;
+  string integrity = 3;
+}
+
 message Value {
   oneof variant {
     string string = 1;

--- a/proto/runtime/runtime.proto
+++ b/proto/runtime/runtime.proto
@@ -21,10 +21,10 @@ message InstantiateModuleResponse {
 
 message RunModuleRequest {
   string instance_id = 1;
-  map<string, common.Value> input = 2;
+  map<string, common.LabeledData> input = 2;
 }
 
-message RunModuleResponse { map<string, common.Value> output = 1; }
+message RunModuleResponse { map<string, common.LabeledData> output = 1; }
 
 service Runtime {
   rpc InstantiateModule(InstantiateModuleRequest)

--- a/rust/common-ifc/Cargo.toml
+++ b/rust/common-ifc/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "common-ifc"
+description = "Information flow control for Common runtime."
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+common-macros = { workspace = true }
+common-protos = { workspace = true }
+common-tracing = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+

--- a/rust/common-ifc/README.md
+++ b/rust/common-ifc/README.md
@@ -1,0 +1,3 @@
+# common-ifc
+
+Information flow control for Common runtime.

--- a/rust/common-ifc/src/context.rs
+++ b/rust/common-ifc/src/context.rs
@@ -1,0 +1,63 @@
+use crate::{IfcError, Result};
+
+#[cfg(doc)]
+use crate::Policy;
+
+/// Environment a module is being evaluated in,
+/// ordered from least to most "private".
+#[derive(Ord, PartialOrd, Eq, PartialEq, Clone, Debug)]
+pub enum ModuleEnvironment {
+    /// Confidential compute environment.
+    Server,
+    /// On a web browser client.
+    WebBrowser,
+}
+
+/// Represents an execution environment of a module.
+///
+/// Used in [Policy] as requirements for
+/// the minimum level needed to execute a module,
+/// validating against the actual [Context] during
+/// execution.
+pub struct Context {
+    /// Minimum allowed module environment.
+    pub env: ModuleEnvironment,
+}
+
+impl Context {
+    /// Ensures the provided [Context] surpasses
+    /// the threshold for all of this context's requirements.
+    pub fn validate(&self, ctx: &Context, input_name: &str) -> Result<()> {
+        if self.env > ctx.env {
+            return Err(IfcError::InvalidEnvironment(input_name.into()));
+        }
+        Ok(())
+    }
+}
+
+impl From<(ModuleEnvironment,)> for Context {
+    fn from(value: (ModuleEnvironment,)) -> Self {
+        Context { env: value.0 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ModuleEnvironment::*;
+    use common_tracing::common_tracing;
+
+    #[test]
+    #[common_tracing]
+    fn it_validates_context() -> Result<()> {
+        let server = Context::from((Server,));
+        let browser = Context::from((WebBrowser,));
+        let name = "input";
+
+        server.validate(&server, name)?;
+        server.validate(&browser, name)?;
+        browser.validate(&browser, name)?;
+        assert!(browser.validate(&server, name).is_err());
+        Ok(())
+    }
+}

--- a/rust/common-ifc/src/data.rs
+++ b/rust/common-ifc/src/data.rs
@@ -1,0 +1,79 @@
+use crate::{Confidentiality, IfcError, Integrity, Label};
+use common_protos::common as proto;
+use std::str::FromStr;
+
+/// The data that gets passed between runtime modules,
+/// containing the underlying `T` and its confidentiality
+/// and integrity [Label].
+#[derive(PartialEq, Clone, Debug)]
+pub struct Data<T> {
+    /// The inner value.
+    pub value: T,
+    /// [Label] representing confidentiality and integrity
+    /// of `value`.
+    pub label: Label,
+}
+
+impl<T> Data<T> {
+    /// Creates a [Data] from a value `T` using the
+    /// strictest labels: the most confidential, and the
+    /// least integrity.
+    pub fn with_strict_labels(value: T) -> Self {
+        Data {
+            value,
+            label: Label::default(),
+        }
+    }
+}
+
+impl<T> TryFrom<proto::LabeledData> for Data<T>
+where
+    T: TryFrom<proto::Value>,
+{
+    type Error = IfcError;
+    fn try_from(data: proto::LabeledData) -> Result<Self, Self::Error> {
+        Ok(Data {
+            value: data
+                .value
+                .ok_or(IfcError::Conversion)?
+                .try_into()
+                .map_err(|_| IfcError::Conversion)?,
+            label: (
+                Confidentiality::from_str(&data.confidentiality)?,
+                Integrity::from_str(&data.integrity)?,
+            )
+                .into(),
+        })
+    }
+}
+
+impl<T> From<Data<T>> for proto::LabeledData
+where
+    T: Into<proto::Value>,
+{
+    fn from(data: Data<T>) -> Self {
+        proto::LabeledData {
+            value: Some(data.value.into()),
+            confidentiality: data.label.confidentiality.to_string(),
+            integrity: data.label.integrity.to_string(),
+        }
+    }
+}
+
+impl<T> From<(T, Confidentiality, Integrity)> for Data<T> {
+    fn from(data: (T, Confidentiality, Integrity)) -> Self {
+        Data {
+            value: data.0,
+            label: (data.1, data.2).into(),
+        }
+    }
+}
+
+impl<T> From<(T, Label)> for Data<T> {
+    fn from(data: (T, Label)) -> Self {
+        Data {
+            value: data.0,
+            label: data.1,
+        }
+    }
+}

--- a/rust/common-ifc/src/error.rs
+++ b/rust/common-ifc/src/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+/// Result type for [IfcError].
+pub type Result<T> = ::core::result::Result<T, IfcError>;
+
+/// Errors for policy validation and other errors.
+#[derive(PartialEq, Error, Debug)]
+pub enum IfcError {
+    /// There was an error during deserializing or
+    /// converting data.
+    #[error("Conversion error")]
+    Conversion,
+    /// The policy is malformed or illegal.
+    #[error("{0}")]
+    InvalidPolicy(String),
+    /// The environment is insufficient based on the policy.
+    #[error("Input '{0}' has insufficient permission to execute in this environment")]
+    InvalidEnvironment(String),
+}

--- a/rust/common-ifc/src/labels.rs
+++ b/rust/common-ifc/src/labels.rs
@@ -1,0 +1,210 @@
+use crate::{Data, IfcError};
+use common_macros::Lattice;
+use std::{
+    fmt::{Debug, Display},
+    slice::Iter,
+    str::FromStr,
+};
+
+/// Trait representing a partially ordered lattice.
+pub trait Lattice: Display + Debug + Ord + PartialOrd + Eq + PartialEq + Sized {
+    /// Return the top-most principal for this lattice.
+    fn top() -> Self;
+    /// Return the bottom-most principal for this lattice.
+    fn bottom() -> Self;
+    /// Returns an iterator that iterates over
+    /// all variants, from lowest to highest.
+    fn iter() -> Iter<'static, Self>;
+}
+
+/// Contains the [Confidentiality] and
+/// [Integrity] describing the confidentiality
+/// and integrity of data `T` associated with [Data].
+#[derive(PartialEq, Debug, Clone, Default)]
+pub struct Label {
+    /// Confidentiality component of [Label].
+    pub confidentiality: Confidentiality,
+    /// Integrity component of [Label].
+    pub integrity: Integrity,
+}
+
+impl Label {
+    /// Create a [Label] that sets its [Confidentiality]
+    /// and [Integrity] to the highest confidentiality
+    /// and lowest integrity found in `input`.
+    pub fn constrain<'a, T, I>(input: I) -> Self
+    where
+        T: 'static,
+        I: IntoIterator<Item = (&'a String, &'a Data<T>)>,
+    {
+        let mut max_conf = Confidentiality::bottom();
+        let mut min_int = Integrity::top();
+        for (_, data) in input {
+            let (conf, int) = (&data.label).into();
+            max_conf = std::cmp::max(max_conf, conf);
+            min_int = std::cmp::min(min_int, int);
+        }
+        (max_conf, min_int).into()
+    }
+}
+
+impl From<(Confidentiality, Integrity)> for Label {
+    fn from(value: (Confidentiality, Integrity)) -> Self {
+        Label {
+            confidentiality: value.0,
+            integrity: value.1,
+        }
+    }
+}
+
+impl From<Label> for (Confidentiality, Integrity) {
+    fn from(value: Label) -> (Confidentiality, Integrity) {
+        (value.confidentiality, value.integrity)
+    }
+}
+
+impl From<&Label> for (Confidentiality, Integrity) {
+    fn from(value: &Label) -> (Confidentiality, Integrity) {
+        value.to_owned().into()
+    }
+}
+
+/// Levels of integrity for a [Data], ordered
+/// from least to most integrity.
+#[derive(Lattice, Default, Ord, PartialOrd, Eq, PartialEq, Clone, Debug)]
+pub enum Integrity {
+    /// The lowest integrity label.
+    #[default]
+    LowIntegrity,
+    /// The highest integrity label.
+    HighIntegrity,
+}
+
+impl Display for Integrity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Integrity::*;
+        write!(
+            f,
+            "{}",
+            match self {
+                HighIntegrity => "HighIntegrity",
+                LowIntegrity => "LowIntegrity",
+            }
+        )
+    }
+}
+
+impl FromStr for Integrity {
+    type Err = IfcError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use Integrity::*;
+        match s {
+            "HighIntegrity" => Ok(HighIntegrity),
+            "LowIntegrity" => Ok(LowIntegrity),
+            _ => Err(IfcError::Conversion),
+        }
+    }
+}
+
+/// Levels of confidentiality for a [Data], ordered
+/// from least to most confidential.
+#[derive(Lattice, Default, Ord, PartialOrd, Eq, PartialEq, Clone, Debug)]
+pub enum Confidentiality {
+    /// The lowest confidentiality label.
+    Public,
+    /// The highest confidentiality label.
+    #[default]
+    Private,
+}
+
+impl Display for Confidentiality {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Confidentiality::*;
+        write!(
+            f,
+            "{}",
+            match self {
+                Private => "Private",
+                Public => "Public",
+            }
+        )
+    }
+}
+
+impl FromStr for Confidentiality {
+    type Err = IfcError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use Confidentiality::*;
+        match s {
+            "Private" => Ok(Private),
+            "Public" => Ok(Public),
+            _ => Err(IfcError::Conversion),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use Confidentiality::*;
+    use Integrity::*;
+
+    #[test]
+    fn it_implements_ordered_lattice_trait() {
+        check_top_gt_bottom::<Confidentiality>();
+        check_top_gt_bottom::<Integrity>();
+        check_iter_order::<Confidentiality>();
+        check_iter_order::<Integrity>();
+
+        fn check_top_gt_bottom<T: Lattice>() {
+            assert!(T::top() > T::bottom());
+        }
+
+        fn check_iter_order<T: 'static + Lattice>() {
+            let mut previous = None;
+            for level in T::iter() {
+                if let Some(previous) = previous {
+                    assert!(previous < level);
+                } else {
+                    assert_eq!(level, &T::bottom())
+                }
+                previous = Some(level);
+            }
+            assert_eq!(previous.unwrap(), &T::top());
+        }
+    }
+
+    #[test]
+    fn it_constrains_from_input() {
+        let private_high = ("vh".into(), Data::from(("data", Private, HighIntegrity)));
+        let private_low = ("vl".into(), Data::from(("data", Private, LowIntegrity)));
+        let public_high = ("bh".into(), Data::from(("data", Public, HighIntegrity)));
+        let public_low = ("bl".into(), Data::from(("data", Public, LowIntegrity)));
+
+        fn input(seq: [&(String, Data<&'static str>); 2]) -> BTreeMap<String, Data<&'static str>> {
+            BTreeMap::from(seq.map(|i| i.to_owned()))
+        }
+
+        assert_eq!(
+            Label::constrain(&input([&private_high, &public_low])),
+            (Private, LowIntegrity).into(),
+        );
+        assert_eq!(
+            Label::constrain(&input([&private_low, &public_high])),
+            (Private, LowIntegrity).into(),
+        );
+        assert_eq!(
+            Label::constrain(&input([&public_low, &public_high])),
+            (Public, LowIntegrity).into(),
+        );
+        assert_eq!(
+            Label::constrain(&input([&private_low, &private_high])),
+            (Private, LowIntegrity).into(),
+        );
+        assert_eq!(
+            Label::constrain(&input([&private_high, &private_high])),
+            (Private, HighIntegrity).into(),
+        );
+    }
+}

--- a/rust/common-ifc/src/lib.rs
+++ b/rust/common-ifc/src/lib.rs
@@ -1,0 +1,24 @@
+#![warn(missing_docs)]
+
+//! Information flow control for Common runtime.
+//!
+//! [Data] wraps a value, tagging it with [Confidentiality]
+//! and [Integrity] labels. A [Policy] contains a map
+//! of these labels and their [Context] requirements,
+//! describing conditions that must be met in order
+//! to permit data flow.
+//!
+//! <https://en.wikipedia.org/wiki/Information_flow_(information_theory)#Information_flow_control>
+
+mod context;
+mod data;
+mod error;
+mod labels;
+mod policy;
+
+pub use common_macros::Lattice;
+pub use context::{Context, ModuleEnvironment};
+pub use data::Data;
+pub use error::{IfcError, Result};
+pub use labels::{Confidentiality, Integrity, Label, Lattice};
+pub use policy::Policy;

--- a/rust/common-ifc/src/policy.rs
+++ b/rust/common-ifc/src/policy.rs
@@ -1,0 +1,158 @@
+use crate::{
+    Confidentiality, Context, Data, IfcError, Integrity, Label, Lattice, ModuleEnvironment, Result,
+};
+use std::collections::BTreeMap;
+
+type PolicyMapInner<T> = BTreeMap<T, Context>;
+
+/// Map of [Confidentiality] or [Integrity]
+/// labels to the minimum allowed [Context].
+///
+/// Map is validated upon construction.
+struct PolicyMap<T: Lattice + 'static>(PolicyMapInner<T>);
+
+impl<T> std::ops::Deref for PolicyMap<T>
+where
+    T: Lattice + 'static,
+{
+    type Target = PolicyMapInner<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> TryFrom<PolicyMapInner<T>> for PolicyMap<T>
+where
+    T: Lattice + 'static,
+{
+    type Error = IfcError;
+
+    /// Constructs a new policy map, validating that
+    /// all labels have defined requirements.
+    fn try_from(map: PolicyMapInner<T>) -> Result<Self> {
+        for label in T::iter() {
+            if !map.contains_key(label) {
+                return Err(IfcError::InvalidPolicy(format!(
+                    "No requirements defined for {label}"
+                )));
+            }
+        }
+        Ok(Self(map))
+    }
+}
+
+/// Represents an invoker's data flow requirements
+/// to verify an execution graph with regard to the provided
+/// data input.
+///
+/// Internally, contains maps of [Confidentiality]
+/// and [Integrity] levels to [Context] requirements.
+pub struct Policy {
+    /// Map of confidentiality principals to the minimum
+    /// required [Context] components.
+    confidentiality_map: PolicyMap<Confidentiality>,
+    /// Map of integrity principals to the minimum
+    /// required [Context] components.
+    integrity_map: PolicyMap<Integrity>,
+}
+
+impl Policy {
+    /// Create a new [Policy], given a map of [Confidentiality]
+    /// and [Integrity] labels to a minimum required [Context].
+    pub fn new<C, I>(confidentiality_map: C, integrity_map: I) -> Result<Self>
+    where
+        C: Into<PolicyMapInner<Confidentiality>>,
+        I: Into<PolicyMapInner<Integrity>>,
+    {
+        let confidentiality_map = confidentiality_map.into().try_into()?;
+        let integrity_map = integrity_map.into().try_into()?;
+        Ok(Self {
+            confidentiality_map,
+            integrity_map,
+        })
+    }
+
+    /// Validate input against this policy, given a [Context].
+    pub fn validate<'a, T, I>(&'a self, input: I, ctx: &Context) -> Result<()>
+    where
+        T: 'static,
+        I: IntoIterator<Item = (&'a String, &'a Data<T>)>,
+    {
+        for (name, data) in input {
+            let (conf_reqs, int_reqs) = self.get_requirements(&data.label)?;
+            conf_reqs.validate(ctx, name)?;
+            int_reqs.validate(ctx, name)?;
+        }
+        Ok(())
+    }
+
+    /// Create a [Policy] from defaults.
+    ///
+    /// Explicitly not using [Default] trait so that
+    /// defaults go through the same validation.
+    pub fn with_defaults() -> Result<Self> {
+        use Confidentiality::*;
+        use Integrity::*;
+        use ModuleEnvironment::*;
+
+        let confidentiality_map = [(Public, (Server,).into()), (Private, (Server,).into())];
+        let integrity_map = [
+            (LowIntegrity, (Server,).into()),
+            (HighIntegrity, (Server,).into()),
+        ];
+
+        Self::new(confidentiality_map, integrity_map)
+    }
+
+    /// Returns the [Context] requirements defined in this policy
+    /// for the given [Label].
+    fn get_requirements(&self, label: &Label) -> Result<(&Context, &Context)> {
+        match (
+            self.confidentiality_map.get(&label.confidentiality),
+            self.integrity_map.get(&label.integrity),
+        ) {
+            (Some(conf_reqs), Some(int_reqs)) => Ok((conf_reqs, int_reqs)),
+            (None, _) => Err(IfcError::InvalidPolicy(format!(
+                "Policy missing confidentiality label '{}'",
+                label.confidentiality
+            ))),
+            (_, None) => Err(IfcError::InvalidPolicy(format!(
+                "Policy missing integrity label '{}'",
+                label.integrity
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Confidentiality::*, Integrity::*, ModuleEnvironment::*};
+    use common_tracing::common_tracing;
+
+    #[test]
+    #[common_tracing]
+    fn it_validates_module_env() -> Result<()> {
+        let input = BTreeMap::from([("in".into(), Data::from(("data", Private, HighIntegrity)))]);
+
+        let policy = Policy::with_defaults()?;
+        assert!(policy.validate(&input, &(Server,).into()).is_ok());
+        assert!(policy.validate(&input, &(WebBrowser,).into()).is_ok());
+
+        // Private data only on BrowserClient
+        let policy = Policy::new(
+            BTreeMap::from([(Public, (Server,).into()), (Private, (WebBrowser,).into())]),
+            BTreeMap::from([
+                (LowIntegrity, (Server,).into()),
+                (HighIntegrity, (Server,).into()),
+            ]),
+        )?;
+        assert_eq!(
+            policy.validate(&input, &(Server,).into()),
+            Err(IfcError::InvalidEnvironment("in".into()))
+        );
+        assert!(policy.validate(&input, &(WebBrowser,).into()).is_ok());
+
+        Ok(())
+    }
+}

--- a/rust/common-macros/Cargo.toml
+++ b/rust/common-macros/Cargo.toml
@@ -10,7 +10,10 @@ proc-macro = true
 
 [dependencies]
 quote = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["full"] }
 
 [features]
 tracing = []
+
+[dev-dependencies]
+common-ifc = { workspace = true }

--- a/rust/common-macros/src/lib.rs
+++ b/rust/common-macros/src/lib.rs
@@ -1,11 +1,10 @@
 #![warn(missing_docs)]
-#![allow(unused)]
 
 //! Macros for common crates.
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, ItemFn};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, ItemFn};
 
 extern crate proc_macro;
 
@@ -35,4 +34,140 @@ pub fn common_tracing(_args: TokenStream, item: TokenStream) -> TokenStream {
         }
     )
     .into()
+}
+
+/// Adds several methods and traits for "new type" structs.
+///
+/// Implements the following methods:
+/// * `Type::inner(&self) -> &Inner`
+/// * `Type::inner_mut(&mut self) -> &mut Inner`
+/// * `Type::into_inner(self) -> Inner`
+///
+/// Implements the following traits:
+/// * `impl Deref for Type`
+/// * `impl DerefMut for Type`
+/// * `impl From<Inner> for Type`
+/// * `impl From<Type> for Inner`
+#[proc_macro_derive(NewType)]
+pub fn derive_new_type(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+    let generics = input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let Data::Struct(data) = input.data else {
+        panic!("NewType only works for struct types.");
+    };
+
+    let Fields::Unnamed(fields) = data.fields else {
+        panic!("NewType requires new type structs.");
+    };
+
+    if fields.unnamed.len() != 1 {
+        panic!("Must be a new type with single inner type.");
+    }
+
+    let inner = fields.unnamed.first().unwrap().ty.clone();
+
+    let expanded = quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            /// Returns the inner type.
+            pub fn inner(&self) -> &#inner {
+                &self.0
+            }
+
+            /// Returns the inner type.
+            pub fn inner_mut(&mut self) -> &mut #inner {
+                &mut self.0
+            }
+
+            /// Returns the inner type.
+            pub fn into_inner(self) -> #inner {
+                self.0
+            }
+        }
+
+        impl #impl_generics ::core::ops::Deref for #name #ty_generics #where_clause {
+            type Target = #inner;
+
+            fn deref(&self) -> &Self::Target {
+                self.inner()
+            }
+        }
+
+        impl #impl_generics ::core::ops::DerefMut for #name #ty_generics #where_clause {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                self.inner_mut()
+            }
+        }
+
+        impl #impl_generics ::core::convert::From<#inner> for #name #ty_generics #where_clause {
+            fn from(value: #inner) -> Self {
+                #name(value)
+            }
+        }
+        impl #impl_generics From<#name #ty_generics> for #inner #where_clause {
+            fn from(value: #name #ty_generics) -> Self {
+                value.into_inner()
+            }
+        }
+    };
+
+    expanded.into()
+}
+
+/// Implements the `common_ifc::Lattice` trait.
+#[proc_macro_derive(Lattice)]
+pub fn derive_lattice(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+    let Data::Enum(data) = input.data else {
+        panic!("LabelType only works for enums.");
+    };
+
+    let mut variants = vec![];
+    for variant in data.variants.iter() {
+        if !matches!(variant.fields, Fields::Unit) {
+            panic!("Only Unit variants are supported.");
+        }
+        let v_name = &variant.ident;
+        variants.push(quote! { #name::#v_name });
+    }
+    let variants_count = variants.len();
+    let Some(bottom) = variants.first() else {
+        panic!("Requires at least one variant.");
+    };
+    let Some(top) = variants.last() else {
+        panic!("Requires at least one variant.");
+    };
+
+    let pkg_name = std::env::var("CARGO_PKG_NAME").ok().unwrap_or_default();
+
+    // Target trait path for consumers, as well as within `common-ifc`.
+    let lattice_trait = if pkg_name == "common-ifc" {
+        quote! { crate::Lattice }
+    } else {
+        quote! { common_ifc::Lattice }
+    };
+
+    let expanded = quote! {
+        impl #lattice_trait for #name {
+            fn top() -> Self {
+                #top
+            }
+
+            fn bottom() -> Self {
+                #bottom
+            }
+
+            fn iter() -> ::core::slice::Iter<'static, #name> {
+                static VARIANTS: [#name; #variants_count] = [#(#variants),*];
+                VARIANTS.iter()
+            }
+        }
+    };
+
+    expanded.into()
 }

--- a/rust/common-macros/tests/lattice.rs
+++ b/rust/common-macros/tests/lattice.rs
@@ -1,0 +1,56 @@
+use common_ifc::Lattice;
+
+#[derive(Lattice, PartialOrd, Ord, PartialEq, Eq, Debug)]
+enum Seasons {
+    Spring,
+    Summer,
+    Autumn,
+    Winter,
+}
+
+impl std::fmt::Display for Seasons {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Seasons::Spring => "Spring",
+                Seasons::Summer => "Summer",
+                Seasons::Autumn => "Autumn",
+                Seasons::Winter => "Winter",
+            },
+        )
+    }
+}
+
+#[test]
+fn it_adds_iter() {
+    let seasons: Vec<&Seasons> = Seasons::iter().collect();
+    assert_eq!(
+        seasons,
+        vec![
+            &Seasons::Spring,
+            &Seasons::Summer,
+            &Seasons::Autumn,
+            &Seasons::Winter,
+        ]
+    );
+}
+
+#[test]
+fn it_orders_iter() {
+    check_iter_order::<Seasons>();
+
+    fn check_iter_order<T: 'static + Lattice>() {
+        let mut previous = None;
+        for level in T::iter() {
+            if let Some(previous) = previous {
+                assert!(previous < level);
+            } else {
+                assert_eq!(level, &T::bottom())
+            }
+            previous = Some(level);
+        }
+        assert_eq!(previous.unwrap(), &T::top());
+    }
+}

--- a/rust/common-macros/tests/new_type.rs
+++ b/rust/common-macros/tests/new_type.rs
@@ -1,0 +1,43 @@
+use common_macros::NewType;
+
+#[derive(NewType, PartialEq, Debug)]
+struct Foo(String);
+
+#[test]
+fn it_adds_methods_and_from_traits() {
+    let string: String = "foo".into();
+    let foo = Foo::from(string.clone());
+
+    assert_eq!(foo, Foo::from(string.clone()));
+    assert_eq!(string, String::from(foo.clone()));
+    assert_eq!(foo.into_inner(), string);
+}
+
+#[test]
+fn it_adds_deref_traits() {
+    use std::ops::{Deref, DerefMut};
+    let string: String = "foo".into();
+    let foo = Foo::from(string.clone());
+    assert_eq!(&string, foo.deref());
+
+    let mut foo = Foo::from(string.clone());
+    let mut_foo = foo.deref_mut();
+    mut_foo.push_str("bar");
+    assert_eq!(foo.deref(), &String::from("foobar"));
+}
+
+#[test]
+fn it_can_use_pub_types() {
+    #[derive(NewType)]
+    struct PubType(pub String);
+}
+
+#[test]
+fn it_handles_generics() {
+    #[derive(NewType)]
+    struct Buffer<T>(Vec<T>);
+
+    let vec: Vec<u8> = vec![0];
+    let buffer = Buffer::from(vec.clone());
+    assert_eq!(vec, Vec::from(buffer));
+}

--- a/rust/common-runtime/Cargo.toml
+++ b/rust/common-runtime/Cargo.toml
@@ -10,6 +10,8 @@ async-trait = { workspace = true }
 async-stream = { workspace = true }
 blake3 = { workspace = true }
 bytes = { workspace = true }
+common-ifc = { workspace = true }
+common-macros = { workspace = true }
 common-protos = { workspace = true, features = ["runtime", "builder"] }
 common-tracing = { workspace = true }
 common-wit = { workspace = true }

--- a/rust/common-runtime/src/error.rs
+++ b/rust/common-runtime/src/error.rs
@@ -1,10 +1,10 @@
+use crate::ModuleInstanceId;
+use common_ifc::IfcError;
 use std::fmt::Debug;
 use thiserror::Error;
 
-use crate::ModuleInstanceId;
-
 /// Various errors that may be encountered when invoking runtime code.
-#[derive(Error, Debug)]
+#[derive(Error, PartialEq, Debug)]
 pub enum CommonRuntimeError {
     /// A Wasm Component failed to prepare
     #[error("Failed to prepare a Wasm Component: {0}")]
@@ -50,11 +50,21 @@ pub enum CommonRuntimeError {
     /// The provided instantiation parameters are not supported
     #[error("Invalid instantiation parameters: {0}")]
     InvalidInstantiationParameters(String),
+
+    /// There was a policy failure.
+    #[error("Policy rejected invocation: {0}")]
+    PolicyRejection(IfcError),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl From<tonic::transport::Error> for CommonRuntimeError {
     fn from(value: tonic::transport::Error) -> Self {
         CommonRuntimeError::InternalError(format!("{value}"))
+    }
+}
+
+impl From<IfcError> for CommonRuntimeError {
+    fn from(value: IfcError) -> Self {
+        CommonRuntimeError::PolicyRejection(value)
     }
 }

--- a/rust/common-runtime/src/lib.rs
+++ b/rust/common-runtime/src/lib.rs
@@ -20,9 +20,6 @@ pub use error::*;
 mod content_type;
 pub use content_type::*;
 
-mod value;
-pub use value::*;
-
 mod module;
 pub use module::*;
 
@@ -38,3 +35,6 @@ mod runtime;
 pub use runtime::*;
 
 pub mod sync;
+
+mod value;
+pub use value::*;

--- a/rust/common-runtime/src/serve/instantiate.rs
+++ b/rust/common-runtime/src/serve/instantiate.rs
@@ -35,7 +35,10 @@ pub async fn instantiate_module(
                 builder_address,
             };
 
-            let initial_io = RuntimeIo::try_from((request.default_input, request.output_shape))?;
+            let initial_io = RuntimeIo::from_initial_state(
+                request.default_input.try_into()?,
+                request.output_shape.try_into()?,
+            );
 
             let mut runtime = runtime.lock().await;
             let instance_id = runtime.compile(module, initial_io).await?;
@@ -58,7 +61,10 @@ pub async fn instantiate_module(
                 id: module_id.to_string(),
             };
 
-            let initial_io = RuntimeIo::try_from((request.default_input, request.output_shape))?;
+            let initial_io = RuntimeIo::from_initial_state(
+                request.default_input.try_into()?,
+                request.output_shape.try_into()?,
+            );
 
             let mut runtime = runtime.lock().await;
 

--- a/rust/common-runtime/src/serve/server.rs
+++ b/rust/common-runtime/src/serve/server.rs
@@ -75,6 +75,7 @@ impl From<CommonRuntimeError> for Status {
             CommonRuntimeError::InvalidInstantiationParameters(_) => {
                 Status::invalid_argument(format!("{value}"))
             }
+            CommonRuntimeError::PolicyRejection(_) => Status::invalid_argument(format!("{value}")),
         }
     }
 }

--- a/rust/common-runtime/src/value.rs
+++ b/rust/common-runtime/src/value.rs
@@ -1,8 +1,8 @@
 use crate::CommonRuntimeError;
-use common_protos::common;
+use common_protos::common as proto;
 
 /// An intrinsic value type within a Common Runtime
-#[derive(Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum Value {
     /// A UTF-8 string
     String(String),
@@ -40,16 +40,16 @@ pub enum ValueKind {
     Buffer,
 }
 
-impl TryFrom<common::Value> for Value {
+impl TryFrom<proto::Value> for Value {
     type Error = CommonRuntimeError;
 
-    fn try_from(value: common::Value) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::Value) -> Result<Self, Self::Error> {
         let value = value.variant.ok_or(CommonRuntimeError::InvalidValue)?;
         Ok(match value {
-            common::value::Variant::String(string) => Value::String(string),
-            common::value::Variant::Number(number) => Value::Number(number),
-            common::value::Variant::Boolean(boolean) => Value::Boolean(boolean),
-            common::value::Variant::Buffer(buffer) => Value::Buffer(buffer),
+            proto::value::Variant::String(string) => Value::String(string),
+            proto::value::Variant::Number(number) => Value::Number(number),
+            proto::value::Variant::Boolean(boolean) => Value::Boolean(boolean),
+            proto::value::Variant::Buffer(buffer) => Value::Buffer(buffer),
         })
     }
 }
@@ -69,26 +69,56 @@ impl std::fmt::Display for Value {
     }
 }
 
-impl From<Value> for common::Value {
+impl From<Value> for proto::Value {
     fn from(value: Value) -> Self {
-        common::Value {
+        proto::Value {
             variant: Some(match value {
-                Value::String(string) => common::value::Variant::String(string),
-                Value::Boolean(number) => common::value::Variant::Boolean(number),
-                Value::Number(boolean) => common::value::Variant::Number(boolean),
-                Value::Buffer(buffer) => common::value::Variant::Buffer(buffer),
+                Value::String(string) => proto::value::Variant::String(string),
+                Value::Boolean(number) => proto::value::Variant::Boolean(number),
+                Value::Number(boolean) => proto::value::Variant::Number(boolean),
+                Value::Buffer(buffer) => proto::value::Variant::Buffer(buffer),
             }),
         }
     }
 }
 
-impl From<common::ValueKind> for ValueKind {
-    fn from(value_kind: common::ValueKind) -> Self {
+impl From<proto::ValueKind> for ValueKind {
+    fn from(value_kind: proto::ValueKind) -> Self {
         match value_kind {
-            common::ValueKind::String => ValueKind::String,
-            common::ValueKind::Boolean => ValueKind::Boolean,
-            common::ValueKind::Number => ValueKind::Number,
-            common::ValueKind::Buffer => ValueKind::Buffer,
+            proto::ValueKind::String => ValueKind::String,
+            proto::ValueKind::Boolean => ValueKind::Boolean,
+            proto::ValueKind::Number => ValueKind::Number,
+            proto::ValueKind::Buffer => ValueKind::Buffer,
         }
+    }
+}
+
+impl From<&str> for Value {
+    fn from(value: &str) -> Self {
+        String::from(value).into()
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::String(value)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Value::Boolean(value)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(value: f64) -> Self {
+        Value::Number(value)
+    }
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(value: Vec<u8>) -> Self {
+        Value::Buffer(value)
     }
 }

--- a/rust/common-runtime/tests/compiled_modules.rs
+++ b/rust/common-runtime/tests/compiled_modules.rs
@@ -50,8 +50,12 @@ async fn it_compiles_and_runs_an_uncompiled_module() -> Result<()> {
             instance_id,
             input: [(
                 "foo".into(),
-                common::Value {
-                    variant: Some(common::value::Variant::String("updated foo".into())),
+                common::LabeledData {
+                    value: Some(common::Value {
+                        variant: Some(common::value::Variant::String("updated foo".into())),
+                    }),
+                    confidentiality: "Public".into(),
+                    integrity: "LowIntegrity".into(),
                 },
             )]
             .into(),
@@ -61,8 +65,12 @@ async fn it_compiles_and_runs_an_uncompiled_module() -> Result<()> {
 
     assert_eq!(
         output.get("bar"),
-        Some(&common::Value {
-            variant: Some(common::value::Variant::String("updated foo:bar".into()))
+        Some(&common::LabeledData {
+            value: Some(common::Value {
+                variant: Some(common::value::Variant::String("updated foo:bar".into()))
+            }),
+            confidentiality: "Public".into(),
+            integrity: "LowIntegrity".into(),
         })
     );
     Ok(())
@@ -131,8 +139,12 @@ async fn it_runs_a_precompiled_module() -> Result<()> {
             instance_id,
             input: [(
                 "foo".into(),
-                common::Value {
-                    variant: Some(common::value::Variant::String("updated foo".into())),
+                common::LabeledData {
+                    value: Some(common::Value {
+                        variant: Some(common::value::Variant::String("updated foo".into())),
+                    }),
+                    confidentiality: "Public".into(),
+                    integrity: "LowIntegrity".into(),
                 },
             )]
             .into(),
@@ -142,8 +154,12 @@ async fn it_runs_a_precompiled_module() -> Result<()> {
 
     assert_eq!(
         output.get("bar"),
-        Some(&common::Value {
-            variant: Some(common::value::Variant::String("updated foo:bar".into()))
+        Some(&common::LabeledData {
+            value: Some(common::Value {
+                variant: Some(common::value::Variant::String("updated foo:bar".into()))
+            }),
+            confidentiality: "Public".into(),
+            integrity: "LowIntegrity".into(),
         })
     );
 

--- a/rust/common-runtime/tests/interpreted_modules.rs
+++ b/rust/common-runtime/tests/interpreted_modules.rs
@@ -48,8 +48,12 @@ async fn it_interprets_and_runs_a_common_script() -> Result<()> {
             instance_id,
             input: [(
                 "foo".into(),
-                common::Value {
-                    variant: Some(common::value::Variant::String("updated foo".into())),
+                common::LabeledData {
+                    value: Some(common::Value {
+                        variant: Some(common::value::Variant::String("updated foo".into())),
+                    }),
+                    confidentiality: "Public".into(),
+                    integrity: "LowIntegrity".into(),
                 },
             )]
             .into(),
@@ -59,8 +63,12 @@ async fn it_interprets_and_runs_a_common_script() -> Result<()> {
 
     assert_eq!(
         output.get("bar"),
-        Some(&common::Value {
-            variant: Some(common::value::Variant::String("updated foo:bar".into()))
+        Some(&common::LabeledData {
+            value: Some(common::Value {
+                variant: Some(common::value::Variant::String("updated foo:bar".into()))
+            }),
+            confidentiality: "Public".into(),
+            integrity: "LowIntegrity".into(),
         })
     );
     Ok(())

--- a/rust/common-runtime/tests/policy.rs
+++ b/rust/common-runtime/tests/policy.rs
@@ -1,0 +1,146 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use anyhow::Result;
+use common_builder::{serve as serve_builder, BuilderError};
+use common_ifc::{Confidentiality, Data, Integrity, ModuleEnvironment, Policy};
+use common_runtime::{
+    ContentType, InputOutput, IoData, IoShape, ModuleSource, RawModule, Runtime, RuntimeIo,
+    SourceCode, Value, ValueKind,
+};
+use common_test_fixtures::sources::common::BASIC_MODULE_JS;
+use common_tracing::common_tracing;
+use common_wit::Target;
+use http::Uri;
+use std::collections::BTreeMap;
+use tokio::{net::TcpListener, task::JoinHandle};
+
+use Confidentiality::*;
+use Integrity::*;
+use ModuleEnvironment::*;
+
+/// Start a build server, returning its address and a task handler.
+async fn init_build_server() -> Result<(Uri, JoinHandle<Result<(), BuilderError>>)> {
+    let builder_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let builder_url = format!("http://{}", builder_listener.local_addr()?);
+    let builder_task = tokio::task::spawn(serve_builder(builder_listener));
+
+    Ok((builder_url.parse()?, builder_task))
+}
+
+fn get_basic_js_module(builder_address: Uri) -> (RawModule, IoShape) {
+    let source = ModuleSource {
+        target: Target::CommonFunctionVm.into(),
+        source_code: [(
+            "module".to_owned(),
+            SourceCode {
+                content_type: ContentType::JavaScript.into(),
+                body: BASIC_MODULE_JS.into(),
+            },
+        )]
+        .into(),
+    };
+    (
+        RawModule::new(source, Some(builder_address)),
+        IoShape::from(BTreeMap::from([("bar".into(), ValueKind::String)])),
+    )
+}
+
+#[macro_export]
+macro_rules! assert_io {
+    ( $runtime:expr, $instance_id:expr, $policy:expr, { $($in_key:expr => $in_val:expr),* } , { $($out_key:expr => $out_val:expr),* }) => {
+        {
+        let mut input = IoData::default();
+        $({
+            let (val, conf_label, int_label) = $in_val;
+            input.insert($in_key.into(), (Value::from(val), conf_label, int_label).into());
+        })*
+        let mut expected_output = IoData::default();
+        $({
+            let (val, conf_label, int_label) = $out_val;
+            expected_output.insert($out_key.into(), (Value::from(val), conf_label, int_label).into());
+        })*
+
+        let input_io = RuntimeIo::new(input, $runtime.output_shape($instance_id)?.to_owned());
+        let output_io = $runtime.run($instance_id, input_io, $policy).await?;
+        let output = output_io.output();
+        let mut expected_keys = vec![];
+
+        for (key, value) in expected_output.iter() {
+            expected_keys.push(key.to_owned());
+            assert_eq!(output.get(key).unwrap(), value);
+        }
+
+        for (key, _) in output.iter() {
+            assert!(expected_keys.contains(key));
+        }
+        }
+    };
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[common_tracing]
+async fn it_propagates_labels() -> Result<()> {
+    let (builder_address, _) = init_build_server().await?;
+    let mut runtime = Runtime::new()?;
+    let (module, output_shape) = get_basic_js_module(builder_address);
+    let instance_id = runtime
+        .interpret(module, RuntimeIo::new(IoData::default(), output_shape))
+        .await?;
+
+    // Private/HighIntegrity stays that way
+    assert_io!(
+        &mut runtime,
+        &instance_id,
+        &Policy::with_defaults()?,
+        {
+            "foo" => ("foo", Private, HighIntegrity)
+        },
+        {
+           "bar" => ("foo:bar", Private, HighIntegrity)
+        }
+    );
+
+    // Public/LowIntegrity stays that way
+    assert_io!(
+        &mut runtime,
+        &instance_id,
+        &Policy::with_defaults()?,
+        {
+            "foo" => ("foo", Public, LowIntegrity)
+        },
+        {
+           "bar" => ("foo:bar", Public, LowIntegrity)
+        }
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[common_tracing]
+async fn it_rejects_based_on_env() -> Result<()> {
+    let (builder_address, _) = init_build_server().await?;
+    let mut runtime = Runtime::new()?;
+    let (module, output_shape) = get_basic_js_module(builder_address);
+    let instance_id = runtime
+        .interpret(module, RuntimeIo::new(IoData::default(), output_shape))
+        .await?;
+
+    // Private data only on BrowserClient
+    let policy = Policy::new(
+        [(Public, (Server,).into()), (Private, (WebBrowser,).into())],
+        [
+            (LowIntegrity, (Server,).into()),
+            (HighIntegrity, (Server,).into()),
+        ],
+    )?;
+
+    let input = IoData::from(BTreeMap::from([(
+        "foo".into(),
+        Data::from((Value::from("foo"), Private, HighIntegrity)),
+    )]));
+    let input_io = RuntimeIo::new(input, runtime.output_shape(&instance_id)?.to_owned());
+    assert!(runtime.run(&instance_id, input_io, &policy).await.is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
* Uses `Data { value: Value, label: Label }` for ports' value-type, wrapping the previous `Value` with additional label fields. Updated throughout the runtime/protobufs. Ports' read/write still operate only on the `Value`.
* Only supporting two levels of confidentiality and integrity currently.
* Only supporting a `PolicyRequirements` ("concept") of `ModuleEnvironment`, either `Server` or `BrowserClient`.
* New-Typing the IO types so we can explicitly use casting traits from/to protobuf mapped types
* ~~Some initial exploration in removing `initial_state`. Mostly using empty defaults for now to show this could be removed, if aligned with product~~. Using `ValueIo` for value maps, used only in initial state such that the gRPC layer does not provide label information for these values, and instead, the most strict labels are used explicitly when creating an initial state.

Currently implemented Features:
* Data output label are based on input labels. Inputs with both "private" and "public" data result in outputs that are labeled "private", for example.
* Tests for Policy to specify which levels of confidentiality/integrity are allowed in different ModuleEnvironments.
* `ModuleEnvironments` hooked up to runtime. All non-wasm runtimes use `System` env, and wasm runtimes use `BrowserClient` env, and all modules are tagged with their runtime's type. In the future this could vary module-by-module. For now, default policy is used in gRPC, but if manually calling the runtime, a strict policy can be provided such that only `BrowserClient` modules can handle `Private` data, or otherwise rejects.