### PR TITLE
fix: Use new common proto Target name

### DIFF
--- a/rust/common-tools/src/commands.rs
+++ b/rust/common-tools/src/commands.rs
@@ -90,7 +90,7 @@ async fn exec_module(
             module_reference: Some(
                 runtime::instantiate_module_request::ModuleReference::ModuleSource(
                     common::ModuleSource {
-                        target: common::Target::CommonScript.into(),
+                        target: common::Target::CommonFunctionVm.into(),
                         source_code: [(
                             "module".into(),
                             common::SourceCode {


### PR DESCRIPTION
Looks like CI didn't run before #79 merged, updating to use new targets from #87