### PR TITLE
feat: Introduce initial abstract graph trait for validating policy

### DIFF
--- a/rust/common-ifc/Cargo.toml
+++ b/rust/common-ifc/Cargo.toml
@@ -12,3 +12,6 @@ common-tracing = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
+[features]
+default = []
+render = []

--- a/rust/common-ifc/src/context.rs
+++ b/rust/common-ifc/src/context.rs
@@ -1,4 +1,4 @@
-use crate::{IfcError, Result};
+use crate::{CommonIfcError, Result};
 
 #[cfg(doc)]
 use crate::Policy;
@@ -29,7 +29,7 @@ impl Context {
     /// the threshold for all of this context's requirements.
     pub fn validate(&self, ctx: &Context, input_name: &str) -> Result<()> {
         if self.env > ctx.env {
-            return Err(IfcError::InvalidEnvironment(input_name.into()));
+            return Err(CommonIfcError::InvalidEnvironment(input_name.into()));
         }
         Ok(())
     }

--- a/rust/common-ifc/src/data.rs
+++ b/rust/common-ifc/src/data.rs
@@ -1,4 +1,4 @@
-use crate::{Confidentiality, IfcError, Integrity, Label};
+use crate::{CommonIfcError, Confidentiality, Integrity, Label};
 use common_protos::common as proto;
 use std::str::FromStr;
 
@@ -30,14 +30,14 @@ impl<T> TryFrom<proto::LabeledData> for Data<T>
 where
     T: TryFrom<proto::Value>,
 {
-    type Error = IfcError;
+    type Error = CommonIfcError;
     fn try_from(data: proto::LabeledData) -> Result<Self, Self::Error> {
         Ok(Data {
             value: data
                 .value
-                .ok_or(IfcError::Conversion)?
+                .ok_or(CommonIfcError::Conversion)?
                 .try_into()
-                .map_err(|_| IfcError::Conversion)?,
+                .map_err(|_| CommonIfcError::Conversion)?,
             label: (
                 Confidentiality::from_str(&data.confidentiality)?,
                 Integrity::from_str(&data.integrity)?,

--- a/rust/common-ifc/src/error.rs
+++ b/rust/common-ifc/src/error.rs
@@ -1,11 +1,11 @@
 use thiserror::Error;
 
-/// Result type for [IfcError].
-pub type Result<T> = ::core::result::Result<T, IfcError>;
+/// Result type for [CommonIfcError].
+pub type Result<T> = ::core::result::Result<T, CommonIfcError>;
 
 /// Errors for policy validation and other errors.
 #[derive(PartialEq, Error, Debug)]
-pub enum IfcError {
+pub enum CommonIfcError {
     /// There was an error during deserializing or
     /// converting data.
     #[error("Conversion error")]
@@ -16,4 +16,22 @@ pub enum IfcError {
     /// The environment is insufficient based on the policy.
     #[error("Input '{0}' has insufficient permission to execute in this environment")]
     InvalidEnvironment(String),
+    /// A graph provided did not pass structural validation.
+    #[error("{0}")]
+    InvalidGraph(String),
+    /// A catch-all error.
+    #[error("{0}")]
+    InternalError(String),
+}
+
+impl From<std::io::Error> for CommonIfcError {
+    fn from(e: std::io::Error) -> Self {
+        CommonIfcError::InternalError(format!("{:#?}", e))
+    }
+}
+
+impl From<std::string::FromUtf8Error> for CommonIfcError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        CommonIfcError::InternalError(format!("{:#?}", e))
+    }
 }

--- a/rust/common-ifc/src/graph/fixtures.rs
+++ b/rust/common-ifc/src/graph/fixtures.rs
@@ -1,0 +1,93 @@
+use crate::graph::{PortGraph, PortGraphNode};
+
+/// [PortGraphNode] type for [TestGraph].
+#[derive(Debug)]
+pub struct TestNode {
+    pub name: String,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+}
+
+impl From<(String, Vec<String>, Vec<String>)> for TestNode {
+    fn from(value: (String, Vec<String>, Vec<String>)) -> Self {
+        TestNode {
+            name: value.0,
+            inputs: value.1,
+            outputs: value.2,
+        }
+    }
+}
+
+impl PortGraphNode<String, String> for TestNode {
+    fn id(&self) -> &String {
+        &self.name
+    }
+    fn inputs<'a>(&'a self) -> impl Iterator<Item = &'a String>
+    where
+        String: 'a,
+    {
+        self.inputs.iter()
+    }
+    fn outputs<'a>(&'a self) -> impl Iterator<Item = &'a String>
+    where
+        String: 'a,
+    {
+        self.outputs.iter()
+    }
+}
+
+pub type TestEdge = ((String, String), (String, String));
+
+/// [PortGraph] type for tests.
+#[derive(Debug)]
+pub struct TestGraph {
+    pub nodes: Vec<TestNode>,
+    pub edges: Vec<TestEdge>,
+}
+
+impl PortGraph for TestGraph {
+    type Node = TestNode;
+    type Edge = TestEdge;
+    type PortName = String;
+    type NodeId = String;
+    fn nodes(&self) -> impl Iterator<Item = &Self::Node> {
+        self.nodes.iter()
+    }
+    fn edges(&self) -> impl Iterator<Item = &Self::Edge> {
+        self.edges.iter()
+    }
+    fn get_node(&self, id: &Self::NodeId) -> Option<&Self::Node> {
+        self.nodes.iter().find(|node| &node.name == id)
+    }
+}
+
+impl TestGraph {
+    /// Construct a [TestGraph] from structures easy-to-express
+    /// in tests.
+    pub fn from_iters<N, E, P>(nodes: N, edges: E) -> TestGraph
+    where
+        N: IntoIterator<Item = (&'static str, P, P)>,
+        E: IntoIterator<Item = ((&'static str, &'static str), (&'static str, &'static str))>,
+        P: IntoIterator<Item = &'static str>,
+    {
+        let mut out_nodes = vec![];
+        let mut out_edges = vec![];
+        for node in nodes.into_iter() {
+            out_nodes.push(TestNode {
+                name: node.0.into(),
+                inputs: node.1.into_iter().map(|s| String::from(s)).collect(),
+                outputs: node.2.into_iter().map(|s| String::from(s)).collect(),
+            });
+        }
+        for edge in edges.into_iter() {
+            out_edges.push((
+                (edge.0 .0.into(), edge.0 .1.into()),
+                (edge.1 .0.into(), edge.1 .1.into()),
+            ));
+        }
+        TestGraph {
+            nodes: out_nodes,
+            edges: out_edges,
+        }
+    }
+}

--- a/rust/common-ifc/src/graph/mod.rs
+++ b/rust/common-ifc/src/graph/mod.rs
@@ -1,0 +1,16 @@
+//! Abstract graph utilities for interacting with a
+//! recipe graph.
+
+#[cfg(test)]
+mod fixtures;
+mod port_graph;
+#[cfg(feature = "render")]
+mod render;
+pub(crate) mod validation;
+
+pub use port_graph::*;
+
+#[cfg(test)]
+pub use fixtures::*;
+#[cfg(feature = "render")]
+pub use render::*;

--- a/rust/common-ifc/src/graph/port_graph.rs
+++ b/rust/common-ifc/src/graph/port_graph.rs
@@ -1,0 +1,128 @@
+use crate::{graph::validation::validate_port_graph, Result};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+};
+
+/// Keyable qualities for node IDs and port names.
+pub trait PortGraphId: Hash + Eq + PartialEq + Display + Debug {}
+impl<T> PortGraphId for T where T: Hash + Eq + PartialEq + Display + Debug {}
+
+/// Type of port, either input or output.
+pub enum PortType {
+    /// Input-type ports.
+    Input,
+    /// Output-type ports.
+    Output,
+}
+
+impl PortType {
+    /// Return a string slice name for this [PortType].
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PortType::Input => "input",
+            PortType::Output => "output",
+        }
+    }
+}
+
+/// A node in a [PortGraph].
+pub trait PortGraphNode<NodeId: PortGraphId, PortName: PortGraphId>: Debug {
+    /// A unique to the graph identifier for this node.
+    fn id(&self) -> &NodeId;
+    /// All input ports for this node.
+    fn inputs<'a>(&'a self) -> impl Iterator<Item = &'a PortName>
+    where
+        PortName: 'a;
+    /// All output ports for this node.
+    fn outputs<'a>(&'a self) -> impl Iterator<Item = &'a PortName>
+    where
+        PortName: 'a;
+}
+
+/// An edge in a [PortGraph].
+pub trait PortGraphEdge<NodeId: PortGraphId, PortName: PortGraphId>: Debug {
+    /// The source connection output port.
+    fn source(&self) -> (&NodeId, &PortName);
+    /// The target connection input port.
+    fn target(&self) -> (&NodeId, &PortName);
+}
+
+impl<NodeId, PortName> PortGraphEdge<NodeId, PortName> for ((NodeId, PortName), (NodeId, PortName))
+where
+    NodeId: PortGraphId,
+    PortName: PortGraphId,
+{
+    fn source(&self) -> (&NodeId, &PortName) {
+        (&self.0 .0, &self.0 .1)
+    }
+    fn target(&self) -> (&NodeId, &PortName) {
+        (&self.1 .0, &self.1 .1)
+    }
+}
+
+/// Trait implementing a Port Graph, a directed graph consisting
+/// of vertices that have named input and output ports,
+/// with edges represented by a directed connection from
+/// one vertex's port to another.
+///
+/// See [PortGraph::validate_port_graph] for expected constraints.
+pub trait PortGraph: Debug {
+    /// Graph's node type.
+    type Node: PortGraphNode<Self::NodeId, Self::PortName>;
+
+    /// Graph's edge type.
+    type Edge: PortGraphEdge<Self::NodeId, Self::PortName>;
+
+    /// The type of node's unique identifier.
+    type NodeId: PortGraphId;
+
+    /// The type of port names.
+    type PortName: PortGraphId;
+
+    /// Return all nodes in the graph.
+    fn nodes(&self) -> impl Iterator<Item = &Self::Node>;
+
+    /// Return all edges in the graph.
+    fn edges(&self) -> impl Iterator<Item = &Self::Edge>;
+
+    /// Returns a node with `id` in the graph if found.
+    fn get_node(&self, id: &Self::NodeId) -> Option<&Self::Node>;
+
+    /// Validates the structure of the graph, ensuring
+    /// the following properties:
+    ///
+    /// * Node ids are unique across all nodes
+    /// * Port ids are unique across ports of the
+    ///   same type in a node (two output ports can't have the same id,
+    ///   but an input and output port can).
+    /// * No unconnected nodes.
+    /// * Edges must contain node and port references
+    ///   that exist in the collection of nodes.
+    /// * No input ports with multiple edges (no fan-in).
+    /// * Edges must be unique across the graph. Implicitly
+    ///   enforced by not allowing fan-in.
+    fn validate_port_graph(&self) -> Result<()> {
+        validate_port_graph(self)
+    }
+
+    /// Get all connections for this node's ports. If
+    /// a `port_type` provided, only connections containing
+    /// that type of node port are returned.
+    fn get_connections<'a>(
+        &'a self,
+        node: &'a Self::Node,
+        port_type: Option<PortType>,
+    ) -> impl Iterator<Item = &'a Self::Edge> {
+        let id = node.id();
+        self.edges().filter(move |edge| {
+            let source = edge.source();
+            let target = edge.target();
+            match port_type {
+                Some(PortType::Input) => target.0 == id,
+                Some(PortType::Output) => source.0 == id,
+                None => source.0 == id || target.0 == id,
+            }
+        })
+    }
+}

--- a/rust/common-ifc/src/graph/render.rs
+++ b/rust/common-ifc/src/graph/render.rs
@@ -1,0 +1,262 @@
+use crate::{
+    graph::{PortGraph, PortGraphEdge, PortGraphNode, PortType},
+    Result,
+};
+use std::io::Write;
+
+/// Render options for the [render_with_options] method.
+pub struct RenderOpts {
+    /// Graph name to display when rendering.
+    pub graph_name: String,
+    /// Whether invisible edges for structural purposes
+    /// should be visible for debugging purposes.
+    pub render_invisibles: bool,
+    /// Font string used in render output.
+    pub font_name: String,
+    /// Font size used in render output.
+    pub font_size: u16,
+    /// Background color of node objects.
+    pub node_background_color: String,
+    /// Background color of port objects.
+    pub port_background_color: String,
+}
+
+impl Default for RenderOpts {
+    fn default() -> Self {
+        RenderOpts {
+            graph_name: "".into(),
+            render_invisibles: false,
+            font_name: "Helvetica,Arial,sans-serif".into(),
+            font_size: 12,
+            node_background_color: "lightgrey".into(),
+            port_background_color: "white".into(),
+        }
+    }
+}
+
+/// Builder pattern for creating a [RenderOpts] via
+/// [RenderOptsBuilder::build], or rendering directly via
+/// [RenderOptsBuilder::render].
+#[derive(Default)]
+pub struct RenderOptsBuilder {
+    opts: RenderOpts,
+}
+
+impl RenderOptsBuilder {
+    /// Set [RenderOpts]' `graph_name`.
+    pub fn graph_name(mut self, graph_name: &str) -> Self {
+        self.opts.graph_name = graph_name.into();
+        self
+    }
+
+    /// Enable [RenderOpts]' `render_invisibles`.
+    pub fn render_invisibles(mut self) -> Self {
+        self.opts.render_invisibles = true;
+        self
+    }
+
+    /// Set [RenderOpts]' `font_name`.
+    pub fn font_name(mut self, font_name: &str) -> Self {
+        self.opts.font_name = font_name.into();
+        self
+    }
+
+    /// Set [RenderOpts]' `font_size`.
+    pub fn font_size(mut self, font_size: u16) -> Self {
+        self.opts.font_size = font_size;
+        self
+    }
+
+    /// Set [RenderOpts]' `node_background_color`.
+    pub fn node_background_color(mut self, color: &str) -> Self {
+        self.opts.node_background_color = color.into();
+        self
+    }
+
+    /// Set [RenderOpts]' `port_background_color`.
+    pub fn port_background_color(mut self, color: &str) -> Self {
+        self.opts.port_background_color = color.into();
+        self
+    }
+
+    /// Return the built [RenderOpts] from this builder.
+    pub fn build(self) -> RenderOpts {
+        self.opts
+    }
+
+    /// Call [render_with_options] with the [RenderOpts] from this builder.
+    pub fn render<G: PortGraph, W: Write>(self, graph: &G, w: W) -> Result<()> {
+        render_with_options(graph, w, self.opts)
+    }
+}
+
+/// Render [PortGraph] as a DOT file to provided writer
+/// with default rendering options.
+/// See [render_with_options] for more.
+pub fn render<G: PortGraph, W: Write>(graph: &G, w: W) -> Result<()> {
+    render_with_options(graph, w, RenderOpts::default())
+}
+
+/// Generates output in [Graphviz](https://www.graphviz.org/) [DOT](https://www.graphviz.org/doc/info/lang.html) format.
+///
+/// Traverses the provided [PortGraph] and writes a DOT file into the provided
+/// writer.
+///
+/// Issues:
+/// * Need to determine what 'dot' legal names are to properly
+///   slugify nodes and ports.
+/// * Need to uniquely slug inputs vs outputs as they can have the same name
+/// * Port names are "scoped" by node names, though there could be collision
+///   e.g. "ModuleX_" and port "foo" could collide with "Module" and port "X_foo"
+///   based on concat/slugging.
+pub fn render_with_options<G: PortGraph, W: Write>(
+    graph: &G,
+    mut w: W,
+    options: RenderOpts,
+) -> Result<()> {
+    let graph_name = options.graph_name;
+    let port_bg = options.port_background_color;
+    let node_bg = options.node_background_color;
+    let font_name = options.font_name;
+    let font_size = options.font_size;
+    let invis_style = match options.render_invisibles {
+        true => "[style=filled,color=red]",
+        false => "[style=invis]",
+    };
+
+    writeln!(
+        w,
+        r#"digraph {{
+label = "{graph_name}";
+graph [fontsize={font_size} fontname="{font_name}"];
+node [style="rounded,filled" color={port_bg} shape=rectangle fontsize={font_size} fontname="{font_name}"];
+edge [fontsize={font_size} fontname="{font_name}"];
+rankdir = "TB";
+"#
+    )?;
+
+    for node in graph.nodes() {
+        let node_id = node.id();
+        writeln!(
+            w,
+            r#"
+subgraph {node_id} {{
+  label = "{node_id}";
+  style = "rounded,filled";
+  color = {node_bg};
+  cluster = true;
+"#
+        )?;
+        let input_slugs = render_ports::<G, W>(&mut w, node, PortType::Input)?;
+        let output_slugs = render_ports::<G, W>(&mut w, node, PortType::Output)?;
+
+        // Render invisible connections between an input
+        // and an output port to create a hierarchy.
+        if let (Some(input_slug), Some(output_slug)) = (input_slugs.first(), output_slugs.first()) {
+            writeln!(w, r#"  {} -> {} {};"#, input_slug, output_slug, invis_style)?;
+        }
+
+        writeln!(w, "}}")?;
+    }
+
+    for node in graph.nodes() {
+        let node_id = node.id();
+        let connections = graph.get_connections(node, Some(PortType::Output));
+        for connection in connections {
+            let source = connection.source();
+            if source.0 == node_id {
+                let target = connection.target();
+                writeln!(
+                    w,
+                    r#"  "{}" -> "{}";"#,
+                    slugify_port::<G>(source.0, source.1),
+                    slugify_port::<G>(target.0, target.1)
+                )?;
+            }
+        }
+    }
+
+    writeln!(w, "}}")?;
+
+    fn render_ports<G: PortGraph, W: Write>(
+        w: &mut W,
+        node: &G::Node,
+        port_type: PortType,
+    ) -> Result<Vec<String>> {
+        let node_id = node.id();
+        let (ports, rank) = match port_type {
+            PortType::Input => (node.inputs().collect::<Vec<_>>(), "source"),
+            PortType::Output => (node.outputs().collect::<Vec<_>>(), "same"),
+        };
+
+        // Open anonymous subgraph,
+        // set rank for inputs to order above outputs,
+        // and override `label`, otherwise repeats the Node label.
+        writeln!(
+            w,
+            r#"
+  subgraph {{
+    rank = {rank};
+    label = "";
+"#
+        )?;
+
+        let mut port_slugs = vec![];
+        for port in ports {
+            let port_slug = slugify_port::<G>(node_id, port);
+            writeln!(w, r#"    "{}" [label="{}"];"#, port_slug, port)?;
+            port_slugs.push(format!(r#""{}""#, port_slug));
+        }
+        // Close anonymous subgraph
+        writeln!(w, "  }}")?;
+
+        Ok(port_slugs)
+    }
+
+    fn slugify_port<G: PortGraph>(node_id: &G::NodeId, port: &G::PortName) -> String {
+        format!("{}__{}", node_id, port)
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        graph::{RenderOptsBuilder, TestGraph},
+        Result,
+    };
+
+    #[test]
+    fn it_renders_to_dot_format() -> Result<()> {
+        let graph = TestGraph::from_iters(
+            [
+                (
+                    "Gems",
+                    vec!["default_in"],
+                    vec!["prompt", "openai_key", "anthropic_key"],
+                ),
+                ("ChatGPT", vec!["prompt", "api_key"], vec!["dream"]),
+                ("Claude", vec!["prompt", "api_key"], vec!["dream"]),
+                ("Synthesize", vec!["result1", "result2"], vec!["final_out"]),
+            ],
+            [
+                (("Gems", "prompt"), ("ChatGPT", "prompt")),
+                (("Gems", "openai_key"), ("ChatGPT", "api_key")),
+                (("Gems", "prompt"), ("Claude", "prompt")),
+                (("Gems", "anthropic_key"), ("Claude", "api_key")),
+                (("ChatGPT", "dream"), ("Synthesize", "result1")),
+                (("Claude", "dream"), ("Synthesize", "result2")),
+                (("Synthesize", "final_out"), ("Gems", "default_in")),
+            ],
+        );
+
+        let mut buffer = std::io::Cursor::new(vec![]);
+        RenderOptsBuilder::default()
+            .graph_name("IFC Example")
+            .render(&graph, &mut buffer)?;
+        let out = String::from_utf8(buffer.into_inner())?;
+        assert!(out.contains("subgraph Gems"));
+        Ok(())
+    }
+}

--- a/rust/common-ifc/src/graph/validation.rs
+++ b/rust/common-ifc/src/graph/validation.rs
@@ -1,0 +1,227 @@
+use crate::{
+    graph::{PortGraph, PortGraphEdge, PortGraphId, PortGraphNode, PortType},
+    CommonIfcError, Result,
+};
+use std::collections::HashSet;
+
+/// Validates a [PortGraph]. See [PortGraph::validate_port_graph] for details.
+pub fn validate_port_graph<G: PortGraph + ?Sized>(graph: &G) -> Result<()> {
+    let mut node_set: HashSet<&G::NodeId> = HashSet::default();
+    let nodes = graph.nodes();
+    for node in nodes {
+        let id = node.id();
+
+        // Check unique node ids
+        if !node_set.insert(id) {
+            return Err(CommonIfcError::InvalidGraph(format!(
+                "Multiple nodes with id '{}' found in graph.",
+                id
+            )));
+        }
+
+        validate_node_ports::<G>(node)?;
+        validate_node_connections::<G>(graph, node)?;
+    }
+    Ok(())
+}
+
+/// Validates a given `node` that all port names are unique
+/// amongst their port types.
+fn validate_node_ports<G: PortGraph + ?Sized>(node: &G::Node) -> Result<()> {
+    let id = node.id();
+
+    check_port_uniqueness(node.inputs(), id, PortType::Input)?;
+    check_port_uniqueness(node.outputs(), id, PortType::Output)?;
+
+    fn check_port_uniqueness<'a, PortName, NodeId, T>(
+        ports: T,
+        node_id: NodeId,
+        port_type: PortType,
+    ) -> Result<()>
+    where
+        PortName: PortGraphId + 'a,
+        NodeId: PortGraphId,
+        T: Iterator<Item = &'a PortName>,
+    {
+        let mut port_set: HashSet<&PortName> = HashSet::default();
+        for port in ports {
+            if !port_set.insert(port) {
+                return Err(CommonIfcError::InvalidGraph(format!(
+                    "Multiple {} ports with name '{}' in node '{}'.",
+                    port_type.as_str(),
+                    port,
+                    node_id
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    Ok(())
+}
+
+/// Validates the connections of `node`, that it is connected
+/// to another node in the graph, an input port doesn't have
+/// multiple incoming connections, and all edges with this node are valid.
+fn validate_node_connections<G: PortGraph + ?Sized>(graph: &G, node: &G::Node) -> Result<()> {
+    let id = node.id();
+    let mut has_connections = false;
+    let mut incoming_set = HashSet::new();
+
+    for edge in graph.get_connections(node, None) {
+        has_connections = true;
+        let source = edge.source();
+        let target = edge.target();
+        validate_port_exists::<G>(graph, source.0, source.1, PortType::Output)?;
+        validate_port_exists::<G>(graph, target.0, target.1, PortType::Input)?;
+
+        if target.0 == id && !incoming_set.insert(target.1) {
+            return Err(CommonIfcError::InvalidGraph(format!(
+                "Input '{}' on node '{}' has multiple incoming connections.",
+                target.1, id
+            )));
+        }
+    }
+
+    if !has_connections {
+        Err(CommonIfcError::InvalidGraph(format!(
+            "Node '{}' is not connected to any other nodes.",
+            id
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Validates the existence of a node with given `node_id`
+/// in the hash map with `port_type` port named `port_name`.
+fn validate_port_exists<G: PortGraph + ?Sized>(
+    graph: &G,
+    node_id: &G::NodeId,
+    port_name: &G::PortName,
+    port_type: PortType,
+) -> Result<()> {
+    if let Some(node) = graph.get_node(node_id) {
+        if match port_type {
+            PortType::Input => node.inputs().any(|p| p == port_name),
+            PortType::Output => node.outputs().any(|p| p == port_name),
+        } {
+            return Ok(());
+        }
+    } else {
+        return Err(CommonIfcError::InvalidGraph(format!(
+            "Node '{}' is not in the graph.",
+            node_id,
+        )));
+    }
+
+    let port_type_name = match port_type {
+        PortType::Input => "input",
+        PortType::Output => "output",
+    };
+    Err(CommonIfcError::InvalidGraph(format!(
+        "Node '{}' does not contain an {} port with the name '{}'.",
+        node_id, port_type_name, port_name,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PortGraph;
+    use crate::graph::TestGraph;
+
+    #[test]
+    fn it_validates_graph() -> crate::Result<()> {
+        let mut graph = TestGraph::from_iters(
+            [
+                ("A", vec![], vec!["a_out_1", "a_out_2"]),
+                ("B", vec!["b_in"], vec!["b_out"]),
+                ("C", vec!["c_in"], vec!["c_out"]),
+                ("D", vec!["d_in_1", "d_in_2", "d_in_3"], vec![]),
+            ],
+            [
+                (("A", "a_out_1"), ("B", "b_in")),
+                (("A", "a_out_2"), ("C", "c_in")),
+                (("B", "b_out"), ("D", "d_in_1")),
+                (("C", "c_out"), ("D", "d_in_2")),
+            ],
+        );
+        graph.validate_port_graph()?;
+
+        // Unconnected nodes should fail.
+        graph
+            .nodes
+            .push(("E".into(), vec!["e_in".into()], vec![]).into());
+        assert!(graph.validate_port_graph().is_err());
+
+        // Connecting should pass, allowing fan-out
+        graph
+            .edges
+            .push((("C".into(), "c_out".into()), ("E".into(), "e_in".into())));
+        graph.validate_port_graph()?;
+
+        // Should not allow fan-in
+        {
+            graph
+                .edges
+                .push((("B".into(), "b_out".into()), ("E".into(), "e_in".into())));
+            assert!(graph.validate_port_graph().is_err());
+            let _ = graph.edges.pop();
+            graph.validate_port_graph()?;
+        }
+
+        // Node ids must be unique.
+        graph
+            .nodes
+            .push(("E".into(), vec!["e_in".into()], vec![]).into());
+        assert!(graph.validate_port_graph().is_err());
+        let _ = graph.nodes.pop();
+
+        // Node ports must be unique among their port types
+        {
+            {
+                let e_node = graph.nodes.last_mut().unwrap();
+                e_node.inputs = vec!["e_in".into(), "e_in".into()];
+            }
+            assert!(graph.validate_port_graph().is_err());
+            {
+                let e_node = graph.nodes.last_mut().unwrap();
+                e_node.inputs = vec!["e_in".into()];
+            }
+            graph.validate_port_graph()?;
+        }
+
+        // Edges must contain references to nodes and ports found in the graph.
+        {
+            graph
+                .edges
+                .push((("C".into(), "c_out".into()), ("Foo".into(), "nope".into())));
+            assert!(graph.validate_port_graph().is_err());
+            let _ = graph.edges.pop();
+            graph
+                .edges
+                .push((("C".into(), "c_out".into()), ("D".into(), "nope".into())));
+            assert!(graph.validate_port_graph().is_err());
+            let _ = graph.edges.pop();
+            graph
+                .edges
+                .push((("Foo".into(), "nope".into()), ("D".into(), "d_in_3".into())));
+            assert!(graph.validate_port_graph().is_err());
+            let _ = graph.edges.pop();
+            graph
+                .edges
+                .push((("B".into(), "nope".into()), ("D".into(), "d_in_3".into())));
+            assert!(graph.validate_port_graph().is_err());
+            let _ = graph.edges.pop();
+            // Also checks validity when connecting an input to an output
+            graph
+                .edges
+                .push((("B".into(), "b_in".into()), ("C".into(), "c_out".into())));
+            assert!(graph.validate_port_graph().is_err());
+            let _ = graph.edges.pop();
+            graph.validate_port_graph()?;
+        }
+
+        Ok(())
+    }
+}

--- a/rust/common-ifc/src/labels.rs
+++ b/rust/common-ifc/src/labels.rs
@@ -1,4 +1,4 @@
-use crate::{Data, IfcError};
+use crate::{CommonIfcError, Data};
 use common_macros::Lattice;
 use std::{
     fmt::{Debug, Display},
@@ -95,13 +95,13 @@ impl Display for Integrity {
 }
 
 impl FromStr for Integrity {
-    type Err = IfcError;
+    type Err = CommonIfcError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use Integrity::*;
         match s {
             "HighIntegrity" => Ok(HighIntegrity),
             "LowIntegrity" => Ok(LowIntegrity),
-            _ => Err(IfcError::Conversion),
+            _ => Err(CommonIfcError::Conversion),
         }
     }
 }
@@ -132,13 +132,13 @@ impl Display for Confidentiality {
 }
 
 impl FromStr for Confidentiality {
-    type Err = IfcError;
+    type Err = CommonIfcError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use Confidentiality::*;
         match s {
             "Private" => Ok(Private),
             "Public" => Ok(Public),
-            _ => Err(IfcError::Conversion),
+            _ => Err(CommonIfcError::Conversion),
         }
     }
 }

--- a/rust/common-ifc/src/lib.rs
+++ b/rust/common-ifc/src/lib.rs
@@ -13,12 +13,13 @@
 mod context;
 mod data;
 mod error;
+pub mod graph;
 mod labels;
 mod policy;
 
 pub use common_macros::Lattice;
 pub use context::{Context, ModuleEnvironment};
 pub use data::Data;
-pub use error::{IfcError, Result};
+pub use error::{CommonIfcError, Result};
 pub use labels::{Confidentiality, Integrity, Label, Lattice};
 pub use policy::Policy;

--- a/rust/common-ifc/src/policy.rs
+++ b/rust/common-ifc/src/policy.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Confidentiality, Context, Data, IfcError, Integrity, Label, Lattice, ModuleEnvironment, Result,
+    CommonIfcError, Confidentiality, Context, Data, Integrity, Label, Lattice, ModuleEnvironment,
+    Result,
 };
 use std::collections::BTreeMap;
 
@@ -25,14 +26,14 @@ impl<T> TryFrom<PolicyMapInner<T>> for PolicyMap<T>
 where
     T: Lattice + 'static,
 {
-    type Error = IfcError;
+    type Error = CommonIfcError;
 
     /// Constructs a new policy map, validating that
     /// all labels have defined requirements.
     fn try_from(map: PolicyMapInner<T>) -> Result<Self> {
         for label in T::iter() {
             if !map.contains_key(label) {
-                return Err(IfcError::InvalidPolicy(format!(
+                return Err(CommonIfcError::InvalidPolicy(format!(
                     "No requirements defined for {label}"
                 )));
             }
@@ -112,11 +113,11 @@ impl Policy {
             self.integrity_map.get(&label.integrity),
         ) {
             (Some(conf_reqs), Some(int_reqs)) => Ok((conf_reqs, int_reqs)),
-            (None, _) => Err(IfcError::InvalidPolicy(format!(
+            (None, _) => Err(CommonIfcError::InvalidPolicy(format!(
                 "Policy missing confidentiality label '{}'",
                 label.confidentiality
             ))),
-            (_, None) => Err(IfcError::InvalidPolicy(format!(
+            (_, None) => Err(CommonIfcError::InvalidPolicy(format!(
                 "Policy missing integrity label '{}'",
                 label.integrity
             ))),
@@ -149,7 +150,7 @@ mod tests {
         )?;
         assert_eq!(
             policy.validate(&input, &(Server,).into()),
-            Err(IfcError::InvalidEnvironment("in".into()))
+            Err(CommonIfcError::InvalidEnvironment("in".into()))
         );
         assert!(policy.validate(&input, &(WebBrowser,).into()).is_ok());
 

--- a/rust/common-runtime/src/error.rs
+++ b/rust/common-runtime/src/error.rs
@@ -1,5 +1,5 @@
 use crate::ModuleInstanceId;
-use common_ifc::IfcError;
+use common_ifc::CommonIfcError;
 use std::fmt::Debug;
 use thiserror::Error;
 
@@ -53,7 +53,7 @@ pub enum CommonRuntimeError {
 
     /// There was a policy failure.
     #[error("Policy rejected invocation: {0}")]
-    PolicyRejection(IfcError),
+    PolicyRejection(CommonIfcError),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -63,8 +63,8 @@ impl From<tonic::transport::Error> for CommonRuntimeError {
     }
 }
 
-impl From<IfcError> for CommonRuntimeError {
-    fn from(value: IfcError) -> Self {
+impl From<CommonIfcError> for CommonRuntimeError {
+    fn from(value: CommonIfcError) -> Self {
         CommonRuntimeError::PolicyRejection(value)
     }
 }


### PR DESCRIPTION
Currently minimal methods and a renderer.

```rust
 let graph = TestGraph::from_iters([
        (
            "Gems",
            vec!["default_in"],
            vec!["prompt", "openai_key", "anthropic_key"],
        ),
        ("ChatGPT", vec!["prompt", "api_key"], vec!["dream"]),
        ("Claude", vec!["prompt", "api_key"], vec!["dream"]),
        ("Synthesize", vec!["result1", "result2"], vec!["final_out"]),
    ],
    [
        (("Gems", "prompt"), ("ChatGPT", "prompt")),
        (("Gems", "openai_key"), ("ChatGPT", "api_key")),
        (("Gems", "prompt"), ("Claude", "prompt")),
        (("Gems", "anthropic_key"), ("Claude", "api_key")),
        (("ChatGPT", "dream"), ("Synthesize", "result1")),
        (("Claude", "dream"), ("Synthesize", "result2")),
        (("Synthesize", "final_out"), ("Gems", "default_in")),
    ],
);

graph.validate_port_graph()?;

let mut f = std::fs::File::create("example.dot")?;
RenderOptsBuilder::default()
    .graph_name("IFC Example")
    .render(&graph, &mut f)?;
```