### PR TITLE
fix: circular dependency in makefile build_wit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ build_rust: .build_rust.done
 	touch .build_rust.done
 
 build_wit: .build_wit.done
-.build_wit.done: ./wit/common/io/wit/deps ./wit/common/function/wit/deps ./rust/common-javascript-interpreter/wit/deps
+.build_wit.done:
 	./wit/wit-tools.sh deps
 	touch .build_wit.done
 


### PR DESCRIPTION
These directories are created by `./wit/wit-tools.sh deps` so if they don't exist initially this step cannot be run. It's a catch-22. I don't see why we need these file dependencies when we already guard against `build_wit` running twice by depending on `.build_wit.done`.