### PR TITLE
feat: Add attribute helper to NewType derive macro 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,7 @@ name = "common-macros"
 version = "0.1.0"
 dependencies = [
  "common-ifc",
+ "darling",
  "quote",
  "syn",
 ]
@@ -1166,6 +1167,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2054,6 +2090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,7 +2842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb182580f71dd070f88d01ce3de9f4da5021db7115d2e1c3605a754153b77c1"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ common-test-fixtures = { path = "./rust/common-test-fixtures" }
 common-tracing = { path = "./rust/common-tracing" }
 common-wit = { path = "./rust/common-wit" }
 criterion = { version = "0.5" }
+darling = { version = "0.20" }
 deno_emit = { version = "0.43" }
 deno_graph = { version = "0.79" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/rust/common-macros/Cargo.toml
+++ b/rust/common-macros/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 proc-macro = true
 
 [dependencies]
+darling = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
 

--- a/rust/common-macros/src/lattice.rs
+++ b/rust/common-macros/src/lattice.rs
@@ -1,0 +1,56 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+pub fn derive_lattice(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+    let Data::Enum(data) = input.data else {
+        panic!("LabelType only works for enums.");
+    };
+
+    let mut variants = vec![];
+    for variant in data.variants.iter() {
+        if !matches!(variant.fields, Fields::Unit) {
+            panic!("Only Unit variants are supported.");
+        }
+        let v_name = &variant.ident;
+        variants.push(quote! { #name::#v_name });
+    }
+    let variants_count = variants.len();
+    let Some(bottom) = variants.first() else {
+        panic!("Requires at least one variant.");
+    };
+    let Some(top) = variants.last() else {
+        panic!("Requires at least one variant.");
+    };
+
+    let pkg_name = std::env::var("CARGO_PKG_NAME").ok().unwrap_or_default();
+
+    // Target trait path for consumers, as well as within `common-ifc`.
+    let lattice_trait = if pkg_name == "common-ifc" {
+        quote! { crate::Lattice }
+    } else {
+        quote! { common_ifc::Lattice }
+    };
+
+    let expanded = quote! {
+        impl #lattice_trait for #name {
+            fn top() -> Self {
+                #top
+            }
+
+            fn bottom() -> Self {
+                #bottom
+            }
+
+            fn iter() -> ::core::slice::Iter<'static, #name> {
+                static VARIANTS: [#name; #variants_count] = [#(#variants),*];
+                VARIANTS.iter()
+            }
+        }
+    };
+
+    expanded.into()
+}

--- a/rust/common-macros/src/lib.rs
+++ b/rust/common-macros/src/lib.rs
@@ -3,8 +3,10 @@
 //! Macros for common crates.
 
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields, ItemFn};
+
+mod lattice;
+mod new_type;
+mod tracing;
 
 extern crate proc_macro;
 
@@ -16,158 +18,63 @@ extern crate proc_macro;
 ///
 /// Implementation defined in `common_tracing::implementation::common_tracing_impl`
 pub fn common_tracing(_args: TokenStream, item: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(item as ItemFn);
-
-    let ItemFn {
-        sig,
-        vis,
-        block,
-        attrs,
-    } = input;
-    let statements = block.stmts;
-
-    quote!(
-        #(#attrs)*
-        #vis #sig {
-            common_tracing::macro_impl::common_tracing_impl();
-            #(#statements)*
-        }
-    )
-    .into()
-}
-
-/// Adds several methods and traits for "new type" structs.
-///
-/// Implements the following methods:
-/// * `Type::inner(&self) -> &Inner`
-/// * `Type::inner_mut(&mut self) -> &mut Inner`
-/// * `Type::into_inner(self) -> Inner`
-///
-/// Implements the following traits:
-/// * `impl Deref for Type`
-/// * `impl DerefMut for Type`
-/// * `impl From<Inner> for Type`
-/// * `impl From<Type> for Inner`
-#[proc_macro_derive(NewType)]
-pub fn derive_new_type(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-
-    let name = input.ident;
-    let generics = input.generics;
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    let Data::Struct(data) = input.data else {
-        panic!("NewType only works for struct types.");
-    };
-
-    let Fields::Unnamed(fields) = data.fields else {
-        panic!("NewType requires new type structs.");
-    };
-
-    if fields.unnamed.len() != 1 {
-        panic!("Must be a new type with single inner type.");
-    }
-
-    let inner = fields.unnamed.first().unwrap().ty.clone();
-
-    let expanded = quote! {
-        impl #impl_generics #name #ty_generics #where_clause {
-            /// Returns the inner type.
-            pub fn inner(&self) -> &#inner {
-                &self.0
-            }
-
-            /// Returns the inner type.
-            pub fn inner_mut(&mut self) -> &mut #inner {
-                &mut self.0
-            }
-
-            /// Returns the inner type.
-            pub fn into_inner(self) -> #inner {
-                self.0
-            }
-        }
-
-        impl #impl_generics ::core::ops::Deref for #name #ty_generics #where_clause {
-            type Target = #inner;
-
-            fn deref(&self) -> &Self::Target {
-                self.inner()
-            }
-        }
-
-        impl #impl_generics ::core::ops::DerefMut for #name #ty_generics #where_clause {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                self.inner_mut()
-            }
-        }
-
-        impl #impl_generics ::core::convert::From<#inner> for #name #ty_generics #where_clause {
-            fn from(value: #inner) -> Self {
-                #name(value)
-            }
-        }
-        impl #impl_generics From<#name #ty_generics> for #inner #where_clause {
-            fn from(value: #name #ty_generics) -> Self {
-                value.into_inner()
-            }
-        }
-    };
-
-    expanded.into()
+    tracing::common_tracing(item)
 }
 
 /// Implements the `common_ifc::Lattice` trait.
 #[proc_macro_derive(Lattice)]
 pub fn derive_lattice(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+    lattice::derive_lattice(input)
+}
 
-    let name = input.ident;
-    let Data::Enum(data) = input.data else {
-        panic!("LabelType only works for enums.");
-    };
-
-    let mut variants = vec![];
-    for variant in data.variants.iter() {
-        if !matches!(variant.fields, Fields::Unit) {
-            panic!("Only Unit variants are supported.");
-        }
-        let v_name = &variant.ident;
-        variants.push(quote! { #name::#v_name });
-    }
-    let variants_count = variants.len();
-    let Some(bottom) = variants.first() else {
-        panic!("Requires at least one variant.");
-    };
-    let Some(top) = variants.last() else {
-        panic!("Requires at least one variant.");
-    };
-
-    let pkg_name = std::env::var("CARGO_PKG_NAME").ok().unwrap_or_default();
-
-    // Target trait path for consumers, as well as within `common-ifc`.
-    let lattice_trait = if pkg_name == "common-ifc" {
-        quote! { crate::Lattice }
-    } else {
-        quote! { common_ifc::Lattice }
-    };
-
-    let expanded = quote! {
-        impl #lattice_trait for #name {
-            fn top() -> Self {
-                #top
-            }
-
-            fn bottom() -> Self {
-                #bottom
-            }
-
-            fn iter() -> ::core::slice::Iter<'static, #name> {
-                static VARIANTS: [#name; #variants_count] = [#(#variants),*];
-                VARIANTS.iter()
-            }
-        }
-    };
-
-    expanded.into()
+/// Creates trait implementations for new type structs.
+///
+/// ```
+/// # use common_macros::NewType;
+/// #[derive(NewType)]
+/// struct Foo(String);
+/// ```
+///
+/// There are several categories of traits that can be optionally
+/// implemented:
+///
+/// * From
+///   * `From<Inner>` for `Type`.
+/// * Into
+///   * `From<Type>` for `Inner`.
+/// * Inner
+///   * `Type::inner(&self) -> &Inner`
+///   * `Type::inner_mut(&mut self) -> &mut Inner`
+///   * `Type::into_inner(self) -> Inner`
+/// * Constructor
+///   * `Type::new(Inner) -> Type`
+/// * Deref
+///   * `Deref<Target = Inner>` for `Type`
+///   * `DerefMut<Target = Inner>` for `Type`
+///
+/// Using the `#[new_type(skip)]` helper, you can opt out of specific
+/// derive categories.
+///
+/// ```
+/// # use common_macros::NewType;
+/// /// Generate implementations for all supported traits,
+/// /// except `Inner` and `Constructor`.
+/// #[derive(NewType)]
+/// #[new_type(skip(Inner, Constructor))]
+/// struct Foo(String);
+/// ```
+///
+/// Similarly, you can specify only the traits to implement
+/// with `#[new_type(only)]`.
+///
+/// ```
+/// # use common_macros::NewType;
+/// /// Only implement `From` and `Into`.
+/// #[derive(NewType)]
+/// #[new_type(only(From, Into))]
+/// struct Foo(String);
+/// ```
+#[proc_macro_derive(NewType, attributes(new_type))]
+pub fn derive_new_type(input: TokenStream) -> TokenStream {
+    new_type::derive_new_type(input)
 }

--- a/rust/common-macros/src/new_type.rs
+++ b/rust/common-macros/src/new_type.rs
@@ -1,0 +1,300 @@
+use darling::{FromDeriveInput, FromMeta};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, Data, DeriveInput, Fields, Generics, Ident, ImplGenerics, Type,
+    TypeGenerics, WhereClause,
+};
+
+#[derive(PartialEq, Clone, Default, Debug, FromMeta)]
+#[darling(default)]
+struct Features {
+    #[darling(rename = "From")]
+    from: bool,
+    #[darling(rename = "Into")]
+    into: bool,
+    #[darling(rename = "Inner")]
+    inner: bool,
+    #[darling(rename = "Constructor")]
+    constructor: bool,
+    #[darling(rename = "Deref")]
+    deref: bool,
+}
+
+impl Features {
+    pub fn invert(mut self) -> Self {
+        self.from = !self.from;
+        self.into = !self.into;
+        self.inner = !self.inner;
+        self.constructor = !self.constructor;
+        self.deref = !self.deref;
+        self
+    }
+}
+
+#[derive(Default, PartialEq, Debug, FromDeriveInput)]
+#[darling(default, attributes(new_type), supports(struct_newtype))]
+struct NewTypeOpts {
+    skip: Option<Features>,
+    only: Option<Features>,
+}
+
+impl NewTypeOpts {
+    /// Returns the list of features to implement, normalized
+    /// to an `only` context.
+    ///
+    /// `only` takes precedence over `skip` if both defined.  
+    pub fn features(&self) -> Features {
+        match (self.skip.clone(), self.only.clone()) {
+            (Some(_), Some(only)) => only,
+            (None, Some(only)) => only,
+            (Some(skip), None) => skip.invert(),
+            (None, None) => Features::default().invert(),
+        }
+    }
+}
+
+struct ParsedInput {
+    name: Ident,
+    inner: Type,
+    generics: Generics,
+}
+
+impl ParsedInput {
+    fn expand(
+        &self,
+    ) -> (
+        &Ident,
+        &Type,
+        ImplGenerics,
+        TypeGenerics,
+        Option<&WhereClause>,
+    ) {
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        (
+            &self.name,
+            &self.inner,
+            impl_generics,
+            ty_generics,
+            where_clause,
+        )
+    }
+}
+
+impl From<(Ident, Type, Generics)> for ParsedInput {
+    fn from(value: (Ident, Type, Generics)) -> Self {
+        ParsedInput {
+            name: value.0,
+            inner: value.1,
+            generics: value.2,
+        }
+    }
+}
+
+pub fn derive_new_type(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let opts = NewTypeOpts::from_derive_input(&input).unwrap();
+    let parsed = parse_new_type(input);
+
+    let mut impls: Vec<TokenStream> = vec![];
+    let features = opts.features();
+
+    if features.from {
+        impls.push(derive_from(&parsed));
+    }
+    if features.into {
+        impls.push(derive_into(&parsed));
+    }
+    if features.constructor {
+        impls.push(derive_constructor(&parsed));
+    }
+    if features.deref {
+        impls.push(derive_deref(&parsed));
+    }
+    if features.inner {
+        impls.push(derive_inner(&parsed));
+    }
+
+    impls.into_iter().collect()
+}
+
+/// Parses a [TokenStream], validates the new type,
+/// and returns a [ParsedInput].
+fn parse_new_type(input: DeriveInput) -> ParsedInput {
+    let name = input.ident;
+    let generics = input.generics;
+
+    let Data::Struct(data) = input.data else {
+        panic!("NewType only works for struct types.");
+    };
+
+    let Fields::Unnamed(fields) = data.fields else {
+        panic!("NewType requires new type structs.");
+    };
+
+    if fields.unnamed.len() != 1 {
+        panic!("Must be a new type with single inner type.");
+    }
+
+    let inner = fields.unnamed.first().unwrap().ty.clone();
+
+    (name, inner, generics).into()
+}
+
+fn derive_from(input: &ParsedInput) -> TokenStream {
+    let (name, inner, impl_generics, ty_generics, where_clause) = input.expand();
+    quote! {
+        impl #impl_generics ::core::convert::From<#inner> for #name #ty_generics #where_clause {
+            fn from(value: #inner) -> Self {
+                #name(value)
+            }
+        }
+    }
+    .into()
+}
+
+fn derive_into(input: &ParsedInput) -> TokenStream {
+    let (name, inner, impl_generics, ty_generics, where_clause) = input.expand();
+    quote! {
+        impl #impl_generics ::core::convert::From<#name #ty_generics> for #inner #where_clause {
+            fn from(value: #name #ty_generics) -> Self {
+                value.0
+            }
+        }
+    }
+    .into()
+}
+
+fn derive_inner(input: &ParsedInput) -> TokenStream {
+    let (name, inner, impl_generics, ty_generics, where_clause) = input.expand();
+    quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            /// Returns the inner type.
+            pub fn inner(&self) -> &#inner {
+                &self.0
+            }
+
+            /// Returns the inner type.
+            pub fn inner_mut(&mut self) -> &mut #inner {
+                &mut self.0
+            }
+
+            /// Returns the inner type.
+            pub fn into_inner(self) -> #inner {
+                self.0
+            }
+        }
+    }
+    .into()
+}
+
+fn derive_deref(input: &ParsedInput) -> TokenStream {
+    let (name, inner, impl_generics, ty_generics, where_clause) = input.expand();
+    quote! {
+        impl #impl_generics ::core::ops::Deref for #name #ty_generics #where_clause {
+            type Target = #inner;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl #impl_generics ::core::ops::DerefMut for #name #ty_generics #where_clause {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    }
+    .into()
+}
+
+fn derive_constructor(input: &ParsedInput) -> TokenStream {
+    let (name, inner, impl_generics, ty_generics, where_clause) = input.expand();
+    quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            /// Creates a new [#name] from a [#inner].
+            pub fn new(inner: #inner) -> Self {
+                Self(inner)
+            }
+        }
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Result<T> = std::result::Result<T, String>;
+
+    fn parse(attrs: &str) -> Result<NewTypeOpts> {
+        let def = format!(
+            r#"
+        #[derive(NewType)]
+        {}
+        struct Foo(u32);"#,
+            attrs
+        );
+        FromDeriveInput::from_derive_input(&syn::parse_str(&def).map_err(|e| format!("{:#?}", e))?)
+            .map_err(|e| format!("Could not parse {}: {}", attrs, e))
+    }
+
+    #[test]
+    fn it_parses_attributes() -> Result<()> {
+        // Redundant "empty" attributes
+        for def in ["", "#[new_type]", "#[new_type()]"] {
+            assert_eq!(
+                parse(def)?,
+                NewTypeOpts {
+                    skip: None,
+                    only: None,
+                },
+            );
+        }
+
+        // Parses `only`
+        assert_eq!(
+            parse("#[new_type(only(From, Into))]")?,
+            NewTypeOpts {
+                skip: None,
+                only: Some(Features {
+                    from: true,
+                    into: true,
+                    ..Default::default()
+                }),
+            }
+        );
+
+        // Parses `skip`
+        assert_eq!(
+            parse("#[new_type(skip(Constructor))]")?,
+            NewTypeOpts {
+                skip: Some(Features {
+                    constructor: true,
+                    ..Default::default()
+                }),
+                only: None,
+            }
+        );
+
+        // Parseable, but derive macro will reject
+        // if both `only` and `skip` provided.
+        assert_eq!(
+            parse("#[new_type(only(From, Into), skip(Constructor))]")?,
+            NewTypeOpts {
+                skip: Some(Features {
+                    constructor: true,
+                    ..Default::default()
+                }),
+                only: Some(Features {
+                    from: true,
+                    into: true,
+                    ..Default::default()
+                }),
+            },
+            "Defaults to `only`."
+        );
+
+        Ok(())
+    }
+}

--- a/rust/common-macros/src/tracing.rs
+++ b/rust/common-macros/src/tracing.rs
@@ -1,0 +1,24 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+pub fn common_tracing(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemFn);
+
+    let ItemFn {
+        sig,
+        vis,
+        block,
+        attrs,
+    } = input;
+    let statements = block.stmts;
+
+    quote!(
+        #(#attrs)*
+        #vis #sig {
+            common_tracing::macro_impl::common_tracing_impl();
+            #(#statements)*
+        }
+    )
+    .into()
+}

--- a/rust/common-macros/tests/new_type.rs
+++ b/rust/common-macros/tests/new_type.rs
@@ -1,35 +1,67 @@
 use common_macros::NewType;
 
-#[derive(NewType, PartialEq, Debug)]
-struct Foo(String);
-
 #[test]
-fn it_adds_methods_and_from_traits() {
-    let string: String = "foo".into();
-    let foo = Foo::from(string.clone());
+fn it_derives_from_inner() {
+    #[derive(NewType)]
+    struct Foo(pub String);
 
-    assert_eq!(foo, Foo::from(string.clone()));
-    assert_eq!(string, String::from(foo.clone()));
-    assert_eq!(foo.into_inner(), string);
+    let s = String::from("foo");
+    let foo = Foo::from(s.clone());
+    assert_eq!(foo.0, s);
 }
 
 #[test]
-fn it_adds_deref_traits() {
-    use std::ops::{Deref, DerefMut};
-    let string: String = "foo".into();
-    let foo = Foo::from(string.clone());
-    assert_eq!(&string, foo.deref());
+fn it_derives_into_inner() {
+    #[derive(NewType)]
+    struct Foo(pub String);
 
-    let mut foo = Foo::from(string.clone());
+    let s = String::from("foo");
+    let foo = Foo(s.clone());
+    let out: String = foo.into();
+    assert_eq!(out, s);
+}
+
+#[test]
+fn it_derives_deref() {
+    use std::ops::{Deref as DerefTrait, DerefMut as DerefMutTrait};
+    #[derive(Clone, NewType)]
+    struct Foo(pub String);
+
+    let s = String::from("foo");
+    let foo = Foo(s.clone());
+    assert_eq!(&s, foo.deref());
+
+    let mut foo = foo.clone();
     let mut_foo = foo.deref_mut();
     mut_foo.push_str("bar");
     assert_eq!(foo.deref(), &String::from("foobar"));
 }
 
 #[test]
-fn it_can_use_pub_types() {
-    #[derive(NewType)]
-    struct PubType(pub String);
+fn it_derives_constructor() {
+    #[derive(Clone, NewType)]
+    struct Foo(pub String);
+
+    let s = String::from("foo");
+    let foo = Foo::new(s.clone());
+    assert_eq!(foo.0, s);
+}
+
+#[test]
+fn it_derives_inner() {
+    #[derive(Clone, NewType)]
+    struct Foo(pub String);
+
+    let s = String::from("foo");
+    let mut foo = Foo(s.clone());
+    assert_eq!(foo.inner(), &s);
+
+    {
+        let inner = foo.inner_mut();
+        inner.push_str("bar");
+    }
+
+    assert_eq!(foo.into_inner(), String::from("foobar"));
 }
 
 #[test]
@@ -40,4 +72,58 @@ fn it_handles_generics() {
     let vec: Vec<u8> = vec![0];
     let buffer = Buffer::from(vec.clone());
     assert_eq!(vec, Vec::from(buffer));
+}
+
+#[test]
+fn it_only_includes_traits_helper() {
+    #[derive(NewType)]
+    #[new_type(only(From))]
+    struct Foo(pub String);
+
+    // This will fail if already defined
+    impl From<Foo> for String {
+        fn from(value: Foo) -> Self {
+            value.0
+        }
+    }
+
+    let s = String::from("foo");
+    let foo = Foo::from(s.clone());
+    assert_eq!(foo.0, s);
+}
+
+#[test]
+fn it_skips_includes_traits_helper() {
+    #[derive(NewType)]
+    #[new_type(skip(From))]
+    struct Foo(pub String);
+
+    // This will fail if already defined
+    impl From<String> for Foo {
+        fn from(value: String) -> Self {
+            Foo(value)
+        }
+    }
+
+    let s = String::from("foo");
+    let foo = Foo::from(s.clone());
+    assert_eq!(String::from(foo), s);
+}
+
+#[test]
+fn it_prioritizes_only_over_skip() {
+    #[derive(NewType)]
+    #[new_type(only(Constructor), skip(Constructor))]
+    struct Foo(pub String);
+
+    // This will fail if already defined
+    impl From<String> for Foo {
+        fn from(value: String) -> Self {
+            Foo(value)
+        }
+    }
+
+    let s = String::from("foo");
+    let foo = Foo::new(s.clone());
+    assert_eq!(foo.0, s);
 }


### PR DESCRIPTION
Add attribute helper to NewType derive macro to customize which traits and functions to implement

Creates trait implementations for new type structs.
```rust
#[derive(NewType)]
struct Foo(String);
```
There are several categories of traits that can be optionally implemented:
* From
  * `From<Inner>` for `Type`.
* Into
  * `From<Type>` for `Inner`.
* Inner
  * `Type::inner(&self) -> &Inner`
  * `Type::inner_mut(&mut self) -> &mut Inner`
  * `Type::into_inner(self) -> Inner`
* Constructor
  * `Type::new(Inner) -> Type`
* Deref
  * `Deref<Target = Inner>` for `Type`
  * `DerefMut<Target = Inner>` for `Type`

Using the `#[new_type(skip)]` helper, you can opt out of specific derive categories.

```rust
/// Generate implementations for all supported traits,
/// except `Inner` and `Constructor`.
#[derive(NewType)]
#[new_type(skip(Inner, Constructor))]
struct Foo(String);
```

Similarly, you can specify only the traits to implement with `#[new_type(only)]`.

```rust
/// Only implement `From` and `Into`.
#[derive(NewType)]
#[new_type(only(From, Into))]
struct Foo(String);
```