### PR TITLE
feat: update github actions upload-artifact/download-artifact to v4.

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -127,7 +127,7 @@ jobs:
             --release
         env:
           RUST_LOG: debug
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wasm-components
           path: ./target/wasm32-wasip1/release/common_javascript_interpreter.wasm
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - name: 'Install OS packages (Ubuntu)'
         if: ${{ matrix.platform == 'ubuntu-latest' }}
         run: |
@@ -188,7 +188,7 @@ jobs:
             --profile ci --color always 2>&1 | tee test-results/log
         env:
           RUST_LOG: debug
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ hashFiles('./test-results') }}
           path: ./test-results

--- a/.github/workflows/workflow_analysis.yaml
+++ b/.github/workflows/workflow_analysis.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
       - name: Parse test results
         id: parse-test-results
         run: |


### PR DESCRIPTION
Looks like #113 and #112 may need to be updated in unison; confirming that here