### PR TITLE
chore: Fix up doc links, add doc tests

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -131,6 +131,43 @@ jobs:
         with:
           name: wasm-components
           path: ./target/wasm32-wasip1/release/common_javascript_interpreter.wasm
+  
+  docs:
+    name: 'Documentation tests'
+    needs: ['lints', 'build-wasm-components']
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/download-artifact@v4
+      - name: 'Install OS packages (Ubuntu)'
+        run: |
+          sudo apt update && sudo apt upgrade -y
+          sudo apt install -y protobuf-compiler libprotobuf-dev tree
+      - name: 'Setup Rust'
+        run: |
+          curl -sSf https://sh.rustup.rs | sh -s -- -y
+          rustup toolchain install stable
+          rustup +stable target add wasm32-unknown-unknown
+      - name: 'Setup Node/NPM'
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.10.3
+      - name: Install binaries from cargo
+        run: |
+          cargo +stable binstall cargo-component cargo-nextest wasm-bindgen-cli wit-deps-cli wasm-tools --no-confirm --force
+      - name: 'Install NPM dependencies'
+        run: |
+          npm install -g @bytecodealliance/jco@1.4.4 @bytecodealliance/componentize-js@0.9.0
+      - name: 'Initialize wits'
+        run: |
+          ./wit/wit-tools.sh deps
+      - name: 'Run Rust tests'
+        shell: bash
+        run: |
+          cargo test --doc --all-features
 
   native-target-tests:
     name: 'Native target tests'

--- a/rust/common-builder/src/bake/javascript.rs
+++ b/rust/common-builder/src/bake/javascript.rs
@@ -10,7 +10,7 @@ use tokio::process::Command;
 use tokio::task::JoinSet;
 use tracing::instrument;
 
-/// A JavaScript-based [Bake] implementation,
+/// A JavaScript-based [`Bake`] implementation,
 /// using `jco`.
 #[derive(Debug)]
 pub struct JavaScriptBaker {}

--- a/rust/common-builder/src/bake/mod.rs
+++ b/rust/common-builder/src/bake/mod.rs
@@ -11,11 +11,11 @@ pub use r#trait::*;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-/// Multivariant implementation of [Bake].
+/// Multivariant implementation of [`Bake`].
 pub enum Baker {
-    /// Uses [JavaScriptBaker].
+    /// Uses [`JavaScriptBaker`].
     JavaScript,
-    /// Uses [PythonBaker].
+    /// Uses [`PythonBaker`].
     Python,
 }
 

--- a/rust/common-builder/src/bake/python.rs
+++ b/rust/common-builder/src/bake/python.rs
@@ -6,7 +6,7 @@ use common_wit::{Target, WitTargetFileMap};
 use tempfile::TempDir;
 use tokio::{process::Command, task::JoinSet};
 
-/// A python-based [Bake] implementation,
+/// A python-based [`Bake`] implementation,
 /// using `componentize-py`.
 #[derive(Debug)]
 pub struct PythonBaker {}

--- a/rust/common-builder/src/bake/trait.rs
+++ b/rust/common-builder/src/bake/trait.rs
@@ -5,7 +5,7 @@ use common_wit::Target;
 
 /// A trait to build a WASM artifact containing WIT modules, and
 /// source code to be executed within the artifact, where specific
-/// implementations of [Bake] provide a runtime to execute that source.
+/// implementations of [`Bake`] provide a runtime to execute that source.
 #[async_trait]
 pub trait Bake {
     /// Build a WASM artifact containing the WIT modules and means

--- a/rust/common-javascript-interpreter/src/lib.rs
+++ b/rust/common-javascript-interpreter/src/lib.rs
@@ -8,6 +8,7 @@
 //! enables us to evaluate `common:module` JavaScript within a Wasm sandbox.
 #[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
 #[allow(warnings)]
+#[rustfmt::skip]
 mod bindings;
 
 #[cfg(all(target_arch = "wasm32", target_os = "wasi"))]

--- a/rust/common-macros/src/lib.rs
+++ b/rust/common-macros/src/lib.rs
@@ -14,7 +14,7 @@ extern crate proc_macro;
 #[cfg(feature = "tracing")]
 #[proc_macro_attribute]
 /// An attribute macro for decorating tests with an
-/// initialized [tracing_subscriber::Subscriber].
+/// initialized `tracing_subscriber::Subscriber`.
 /// Requires the `common_tracing` dependency.
 ///
 /// Implementation defined in `common_tracing::implementation::common_tracing_impl`

--- a/rust/common-macros/src/new_type.rs
+++ b/rust/common-macros/src/new_type.rs
@@ -118,8 +118,8 @@ pub fn derive_new_type(input: TokenStream) -> TokenStream {
     impls.into_iter().collect()
 }
 
-/// Parses a [TokenStream], validates the new type,
-/// and returns a [ParsedInput].
+/// Parses a [`TokenStream`], validates the new type,
+/// and returns a [`ParsedInput`].
 fn parse_new_type(input: DeriveInput) -> ParsedInput {
     let name = input.ident;
     let generics = input.generics;

--- a/rust/common-runtime/src/cache.rs
+++ b/rust/common-runtime/src/cache.rs
@@ -6,10 +6,10 @@ use tokio::sync::Mutex;
 
 use crate::CommonRuntimeError;
 
-/// A general purpose cache for Runtime internals, built around a [SieveCache]
-/// See also: https://cachemon.github.io/SIEVE-website/
+/// A general purpose cache for Runtime internals, built around a [`SieveCache`]
+/// See also: <https://cachemon.github.io/SIEVE-website/>
 ///
-/// [Cache] is cheaply cloneable and threadsafe.
+/// [`Cache`] is cheaply cloneable and threadsafe.
 #[derive(Clone)]
 pub struct Cache<K, V>(Arc<Mutex<SieveCache<K, V>>>)
 where
@@ -21,7 +21,7 @@ where
     K: Eq + Hash + Clone,
     V: Clone,
 {
-    /// Instantiate a new [Cache] with a given capacity
+    /// Instantiate a new [`Cache`] with a given capacity
     pub fn new(capacity: usize) -> Result<Self, CommonRuntimeError> {
         Ok(Cache(Arc::new(Mutex::new(
             SieveCache::new(capacity)
@@ -29,7 +29,7 @@ where
         ))))
     }
 
-    /// Look up an item that may be in the [Cache]
+    /// Look up an item that may be in the [`Cache`]
     pub async fn get<Q>(&self, key: &Q) -> Option<V>
     where
         Q: Hash + Eq + ?Sized,
@@ -39,7 +39,7 @@ where
         sieve.get(key).cloned()
     }
 
-    /// Add an item to the [Cache], evicting older items if the [Cache] is
+    /// Add an item to the [`Cache`], evicting older items if the [`Cache`] is
     /// already at capacity
     pub async fn insert(&self, key: K, value: V) {
         let mut sieve = self.0.lock().await;

--- a/rust/common-runtime/src/content_type.rs
+++ b/rust/common-runtime/src/content_type.rs
@@ -2,7 +2,10 @@ use std::fmt::Display;
 
 use common_protos::common;
 
-/// Supported content types that may be embodied as a [crate::CommonModule]
+#[cfg(doc)]
+use crate::Module;
+
+/// Supported content types that may be embodied as a [`Module`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ContentType {
     /// JavaScript or TypeScript code

--- a/rust/common-runtime/src/data.rs
+++ b/rust/common-runtime/src/data.rs
@@ -5,18 +5,18 @@ use std::str::FromStr;
 
 /// The data that gets passed between runtime modules,
 /// containing the underlying `T` and its confidentiality
-/// and integrity [Label].
+/// and integrity [`Label`].
 #[derive(PartialEq, Clone, Debug)]
 pub struct Data<T> {
     /// The inner value.
     pub value: T,
-    /// [Label] representing confidentiality and integrity
+    /// [`Label`] representing confidentiality and integrity
     /// of `value`.
     pub label: Label,
 }
 
 impl<T> Data<T> {
-    /// Creates a [Data] from a value `T` using the
+    /// Creates a [`Data`] from a value `T` using the
     /// strictest labels: the most confidential, and the
     /// least integrity.
     pub fn with_strict_labels(value: T) -> Self {

--- a/rust/common-runtime/src/helpers.rs
+++ b/rust/common-runtime/src/helpers.rs
@@ -8,7 +8,7 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
 /// The critical metadata needed to access the virtual environment
-/// that is started by the [start_runtime] helper
+/// that is started by the [`start_runtime`] helper
 pub struct VirtualEnvironment {
     /// A gRPC client that has been configured to access the running
     /// [crate::NativeRuntime]
@@ -25,7 +25,7 @@ pub struct VirtualEnvironment {
 }
 
 /// Starts a `common-runtime` server connected to a `common-builder`,
-/// returning a handle to a [RuntimeClient], and handlers to
+/// returning a handle to a [`RuntimeClient`], and handlers to
 /// tokio threads for the server lifetimes.
 pub async fn start_runtime() -> Result<VirtualEnvironment> {
     let builder_listener = TcpListener::bind("127.0.0.1:0").await?;

--- a/rust/common-runtime/src/lib.rs
+++ b/rust/common-runtime/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! A library that constitutes the substantial implementation of a Common Runtime.
 
-// TODO: All [async_trait::async_trait]-using code must be made compatible with
+// TODO: All [`async_trait::async_trait`]-using code must be made compatible with
 // the `wasm32-unknown-unknown` target.
 
 #[macro_use]

--- a/rust/common-runtime/src/module.rs
+++ b/rust/common-runtime/src/module.rs
@@ -28,12 +28,12 @@ pub use driver::*;
 mod id;
 pub use id::*;
 
-/// [Module] is implemented for types that represent a live, instantiated Module
+/// [`Module`] is implemented for types that represent a live, instantiated Module
 pub trait Module: HasModuleContextMut {
-    /// A [ModuleId] that may be used to look up the Wasm artifact that
-    /// constitutes the [Module]'s substantive implementation
+    /// A [`ModuleId`] that may be used to look up the Wasm artifact that
+    /// constitutes the [`Module`]'s substantive implementation
     fn id(&self) -> &ModuleId;
-    /// A [ModuleInstanceId] uniquely identifies the instance of the [Module]
-    /// among all other instances of it and other [Module]s.
+    /// A [`ModuleInstanceId`] uniquely identifies the instance of the [`Module`]
+    /// among all other instances of it and other [`Module`]s.
     fn instance_id(&self) -> &ModuleInstanceId;
 }

--- a/rust/common-runtime/src/module/body.rs
+++ b/rust/common-runtime/src/module/body.rs
@@ -10,7 +10,7 @@ use super::source_code::SourceCodeCollection;
 /// [crate::ModuleDefinition].
 #[derive(Clone)]
 pub enum ModuleBody {
-    /// A signature body is a [ModuleId] that can be used to look up a pre-built
+    /// A signature body is a [`ModuleId`] that can be used to look up a pre-built
     /// artifact
     Signature(ModuleId),
     /// A source code body contains code that may be built into a runnable
@@ -41,8 +41,8 @@ impl From<(&Target, &ModuleBody)> for ModuleId {
 
 impl ModuleBody {
     // TODO: Module reference should not be a holder of target
-    /// Convert the [ModuleBody] into a [ModuleReference] with the given
-    /// [Target]
+    /// Convert the [`ModuleBody`] into a [`ModuleReference`] with the given
+    /// [`Target`]
     pub fn to_module_reference(&self, target: &Target) -> ModuleReference {
         let target = common::Target::from(target);
         match self {

--- a/rust/common-runtime/src/module/context.rs
+++ b/rust/common-runtime/src/module/context.rs
@@ -4,37 +4,37 @@ use common_ifc::Context as IfcContext;
 /// The basic properties that are required to define the host-to-guest bindings
 /// for a given Common Module
 pub trait ModuleContext: ConditionalSend {
-    /// The type of [InputOutput] in use by the [ModuleContext]
+    /// The type of [`InputOutput`] in use by the [`ModuleContext`]
     type Io: InputOutput;
 
-    /// Read access to the [ModuleContext]'s [InputOutput]
+    /// Read access to the [`ModuleContext`]'s [`InputOutput`]
     fn io(&self) -> &Self::Io;
 
-    /// Read access to the [ModuleContext]'s [IfcContext]
+    /// Read access to the [`ModuleContext`]'s [`IfcContext`]
     fn ifc(&self) -> &IfcContext;
 }
 
-/// Mutable properties that may be required in a [ModuleContext] in order to
+/// Mutable properties that may be required in a [`ModuleContext`] in order to
 /// make use of some Common Modules
 pub trait ModuleContextMut: ModuleContext {
-    /// Read-write access to the [ModuleContext]'s [InputOutput]
+    /// Read-write access to the [`ModuleContext`]'s [`InputOutput`]
     fn io_mut(&mut self) -> &mut Self::Io;
 }
 
-/// A trait that is implemented by things that have a [ModuleContext]. All
+/// A trait that is implemented by things that have a [`ModuleContext`]. All
 /// Common Modules implement this trait.
 pub trait HasModuleContext {
-    /// The type of the [ModuleContext] that backs the implementor
+    /// The type of the [`ModuleContext`] that backs the implementor
     type Context: ModuleContext;
 
-    /// Read access to the [ModuleContext] that backs the implementor
+    /// Read access to the [`ModuleContext`] that backs the implementor
     fn context(&self) -> &Self::Context;
 }
 
-/// A trait that is implemented when a [HasModuleContext] allows mutable
-/// access to its backing [ModuleContext]
+/// A trait that is implemented when a [`HasModuleContext`] allows mutable
+/// access to its backing [`ModuleContext`]
 pub trait HasModuleContextMut: HasModuleContext {
-    /// Mutable access to the [ModuleContext] that backs the implementor
+    /// Mutable access to the [`ModuleContext`] that backs the implementor
     fn context_mut(&mut self) -> &mut Self::Context;
 }
 

--- a/rust/common-runtime/src/module/definition.rs
+++ b/rust/common-runtime/src/module/definition.rs
@@ -13,22 +13,26 @@ pub use function_vm::*;
 mod remote_function;
 pub use remote_function::*;
 
-/// A (de)serializable structure that constitutes a [crate::Module]. A
-/// [ModuleDefinition] can be instantiated as a live Module by a Runtime that
-/// implements an appropriate [crate::ModuleDriver].
+#[cfg(doc)]
+use crate::{Module, ModuleDriver};
+
+/// A (de)serializable structure that constitutes a [`Module`].
+///
+/// A [`ModuleDefinition`] can be instantiated as a live Module by a Runtime that
+/// implements an appropriate [`ModuleDriver`].
 #[derive(Clone)]
 pub struct ModuleDefinition {
-    /// The [Target] of the Module, which is always dereferencable to a WIT
+    /// The [`Target`] of the Module, which is always dereferencable to a WIT
     /// definition
     pub target: Target,
-    /// The [Affinity] of the Module, which informs the Runtime where the Module
+    /// The [`Affinity`] of the Module, which informs the Runtime where the Module
     /// ought to be scheduled relative to the local device
     pub affinity: Affinity,
     /// The shape of the input keys that are able to be read by the Module
     pub inputs: IoShape,
     /// The shape of the output keys that are able to be written-to by the Module
     pub outputs: IoShape,
-    /// The [ModuleBody] represents the substantive implementation of the Module, either
+    /// The [`ModuleBody`] represents the substantive implementation of the Module, either
     /// as inputs that may be used to derive a runnable Wasm artifact
     pub body: ModuleBody,
 }

--- a/rust/common-runtime/src/module/definition/function.rs
+++ b/rust/common-runtime/src/module/definition/function.rs
@@ -5,7 +5,7 @@ use crate::{module::affinity::Affinity, CommonRuntimeError};
 
 use super::ModuleDefinition;
 
-/// A newtype over a [ModuleDefinition]; it can only be constructed for
+/// A newtype over a [`ModuleDefinition`]; it can only be constructed for
 /// definitions whose target is [Target::CommonFunction].and whose affinity
 /// allows for local instantiation.
 #[derive(NewType)]

--- a/rust/common-runtime/src/module/definition/function_vm.rs
+++ b/rust/common-runtime/src/module/definition/function_vm.rs
@@ -7,7 +7,7 @@ use super::ModuleDefinition;
 
 /// Function VM Definition
 ///
-/// A newtype over a [ModuleDefinition]; it can only be constructed for
+/// A newtype over a [`ModuleDefinition`]; it can only be constructed for
 /// definitions whose target is [Target::CommonFunctionVm], whose affinity
 /// allows for local instantiation and whose body is [ModuleBody::SourceCode].
 #[derive(NewType)]
@@ -15,8 +15,8 @@ use super::ModuleDefinition;
 pub struct FunctionVmDefinition(ModuleDefinition);
 
 impl FunctionVmDefinition {
-    /// Get the [ContentType] associated with the with the source code of this
-    /// [ModuleDefinition]
+    /// Get the [`ContentType`] associated with the with the source code of this
+    /// [`ModuleDefinition`]
     pub fn content_type(&self) -> Result<ContentType, CommonRuntimeError> {
         if let ModuleBody::SourceCode(source_code_collection) = &self.0.body {
             if let Some((_, source_code)) = source_code_collection.iter().next() {

--- a/rust/common-runtime/src/module/definition/remote_function.rs
+++ b/rust/common-runtime/src/module/definition/remote_function.rs
@@ -7,7 +7,7 @@ use super::ModuleDefinition;
 
 /// Remote Function Definition
 ///
-/// A newtype over a [ModuleDefinition]; it can only be constructed for
+/// A newtype over a [`ModuleDefinition`]; it can only be constructed for
 /// definitions whose target is [Target::CommonFunction].or [Target::CommonFunctionVm] and whose affinity
 /// allows for remote instantiation.
 #[derive(NewType)]

--- a/rust/common-runtime/src/module/driver.rs
+++ b/rust/common-runtime/src/module/driver.rs
@@ -6,17 +6,17 @@ use super::ModuleFactory;
 
 /// Runtime Module Drivers
 ///
-/// A [ModuleDriver] is implemented by a Runtime for each distinctive form of
+/// A [`ModuleDriver`] is implemented by a Runtime for each distinctive form of
 /// [crate::ModuleDefinition] that it is able to instantiate. The driver
-/// produces a prepared [ModuleFactory] for a given [crate::ModuleDefinition],
+/// produces a prepared [`ModuleFactory`] for a given [crate::ModuleDefinition],
 /// which can in turn be used to instantiate a [crate::Module].
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait ModuleDriver<D> {
-    /// The type of the [ModuleFactory] that is produced by this [ModuleDriver]
+    /// The type of the [`ModuleFactory`] that is produced by this [`ModuleDriver`]
     type ModuleFactory: ModuleFactory;
 
-    /// Prepare a Module, producing a [ModuleFactory] that may be used to instantiate an associated [crate::Module] many times (relatively cheaply).
+    /// Prepare a Module, producing a [`ModuleFactory`] that may be used to instantiate an associated [crate::Module] many times (relatively cheaply).
     /// Preparation typically entails resolving a Wasm artifact for the Module body, compiling that artifact and caching all the metadata required to instantiate it.
     async fn prepare(&self, definition: D) -> Result<Self::ModuleFactory, CommonRuntimeError>;
 }

--- a/rust/common-runtime/src/module/factory.rs
+++ b/rust/common-runtime/src/module/factory.rs
@@ -4,21 +4,21 @@ use crate::{sync::ConditionalSync, CommonRuntimeError};
 
 use super::{Module, ModuleContext};
 
-/// A [ModuleFactory] constitutes a prepared Module, which may be instantiated
+/// A [`ModuleFactory`] constitutes a prepared Module, which may be instantiated
 /// many times relatively cheaply.
 ///
-/// [ModuleFactory]s are typically produced by an implementor of a
+/// [`ModuleFactory`]s are typically produced by an implementor of a
 /// [crate::ModuleDriver].
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait ModuleFactory: Clone + ConditionalSync {
-    /// The type of the backing [ModuleContext] that is used by this [ModuleFactory]
+    /// The type of the backing [`ModuleContext`] that is used by this [`ModuleFactory`]
     type Context: ModuleContext;
-    /// The type of the [Module] that is instantiated by this [ModuleFactory]
+    /// The type of the [`Module`] that is instantiated by this [`ModuleFactory`]
     type Module: Module<Context = Self::Context>;
 
-    /// Given a [ModuleContext], instantiate the [Module] that this
-    /// [ModuleFactory] represents
+    /// Given a [`ModuleContext`], instantiate the [`Module`] that this
+    /// [`ModuleFactory`] represents
     async fn instantiate(&self, context: Self::Context)
         -> Result<Self::Module, CommonRuntimeError>;
 }

--- a/rust/common-runtime/src/module/id.rs
+++ b/rust/common-runtime/src/module/id.rs
@@ -18,7 +18,7 @@ impl Display for ModuleInstanceId {
     }
 }
 
-/// A [ModuleId] uniquely identifies a given Common Module. At this time it is
+/// A [`ModuleId`] uniquely identifies a given Common Module. At this time it is
 /// always expected to represent the hash of the Common Module's Wasm Component
 /// artifact.
 ///
@@ -26,9 +26,9 @@ impl Display for ModuleInstanceId {
 /// sources, perhaps?
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum ModuleId {
-    /// The [ModuleId] is in the form of [blake3::Hash] bytes.
+    /// The [`ModuleId`] is in the form of [blake3::Hash] bytes.
     Hash(blake3::Hash),
-    /// The [ModuleId] is a base64-encoded string
+    /// The [`ModuleId`] is a base64-encoded string
     Base64(String),
 }
 
@@ -85,7 +85,7 @@ impl TryFrom<ModuleId> for ModuleInstanceId {
 }
 
 impl ModuleId {
-    /// Convert the [ModuleId] to raw bytes corresponding to the [blake3::Hash]
+    /// Convert the [`ModuleId`] to raw bytes corresponding to the [blake3::Hash]
     pub fn to_bytes(&self) -> Result<Vec<u8>, CommonRuntimeError> {
         Ok(match self {
             ModuleId::Hash(hash) => hash.as_bytes().to_vec(),

--- a/rust/common-runtime/src/module/interface/function.rs
+++ b/rust/common-runtime/src/module/interface/function.rs
@@ -7,12 +7,12 @@ use crate::{CommonRuntimeError, InputOutput, IoData, Module, Validated};
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait FunctionInterface: Module {
-    /// The type of [InputOutput] that is expected by the underlying Module
+    /// The type of [`InputOutput`] that is expected by the underlying Module
     /// implementation
     type InputOutput: InputOutput;
 
     /// Invoke `run` on the guest `common:function`, substituting the provided
-    /// [InputOutput] within the Module's execution context.
+    /// [`InputOutput`] within the Module's execution context.
     async fn run(&mut self, io: Validated<Self::InputOutput>)
         -> Result<IoData, CommonRuntimeError>;
 }

--- a/rust/common-runtime/src/module/manager.rs
+++ b/rust/common-runtime/src/module/manager.rs
@@ -1,7 +1,7 @@
 use super::ModuleInstanceId;
 use async_trait::async_trait;
 
-/// [ModuleManager] is implemented for each distinctive [crate::Module] type
+/// [`ModuleManager`] is implemented for each distinctive [crate::Module] type
 /// that is tracked by the implementor. The implementor may then be used to keep
 /// instances of [crate::Module]s alive.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
@@ -9,9 +9,9 @@ use async_trait::async_trait;
 pub trait ModuleManager<T> {
     /// Track a [crate::Module] by retaining a reference to it
     async fn add(&self, module_instance: T) -> ModuleInstanceId;
-    /// Look up a tracked [crate::Module] by [ModuleInstanceId]
+    /// Look up a tracked [crate::Module] by [`ModuleInstanceId`]
     async fn get(&self, id: &ModuleInstanceId) -> Option<T>;
-    /// Take a tracked [crate::Module]; the [ModuleManager] will no longer
+    /// Take a tracked [crate::Module]; the [`ModuleManager`] will no longer
     /// retain a reference to it
     async fn take(&self, id: ModuleInstanceId) -> Option<T>;
 }

--- a/rust/common-runtime/src/module/source_code.rs
+++ b/rust/common-runtime/src/module/source_code.rs
@@ -3,7 +3,7 @@ use bytes::Bytes;
 use common_protos::common;
 use std::collections::BTreeMap;
 
-/// A pairing of raw source code bytes and an associated [ContentType]
+/// A pairing of raw source code bytes and an associated [`ContentType`]
 #[derive(Debug, Clone)]
 pub struct SourceCode {
     /// The mime of the source

--- a/rust/common-runtime/src/policy.rs
+++ b/rust/common-runtime/src/policy.rs
@@ -1,9 +1,10 @@
 use crate::{CommonRuntimeError, InputOutput};
 use common_ifc::{Context as IfcContext, Policy};
 
-/// A type that wraps an inner value that has been validated against some [Policy].
-/// A [Validated] can only be created through a fallible step in which the wrapped
-/// value is validated against the [Policy].
+/// A wrapper around `T` that has been validated against some [`Policy`].
+///
+/// A [`Validated`] can only be created through a fallible step
+/// in which the wrapped value is validated against the [`Policy`].
 pub struct Validated<T> {
     policy: Policy,
     inner: T,
@@ -15,7 +16,7 @@ impl<T> Validated<T> {
         self.inner
     }
 
-    /// The [Policy] that was used to validate the wrapped value
+    /// The [`Policy`] that was used to validate the wrapped value
     pub fn policy(&self) -> &Policy {
         &self.policy
     }

--- a/rust/common-runtime/src/runtime/io.rs
+++ b/rust/common-runtime/src/runtime/io.rs
@@ -5,6 +5,9 @@ use common_protos::common;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
+#[cfg(doc)]
+use crate::ModuleDriver;
+
 /// A wrapper type around the mapping of IO names
 /// for Common Modules.
 #[derive(NewType, Default, Clone, Debug)]
@@ -135,12 +138,12 @@ impl TryFrom<HashMap<String, common::Value>> for IoValues {
 /// A generic trait for a reference to state. The implementation may embody
 /// state that is opaque, readable and/or writable.
 pub trait InputOutput: Clone + Default + ConditionalSync + std::fmt::Debug {
-    /// Attempt to read some [Value] from state that is assigned some well-known
+    /// Attempt to read some [`Value`] from state that is assigned some well-known
     /// `key`. A value may be returned if it is part of the state, and the reader
     /// is allowed to read it.
     fn read(&self, key: &str) -> Option<Value>;
 
-    /// Write some [Value] to a well-known `key`. The write may or may not be
+    /// Write some [`Value`] to a well-known `key`. The write may or may not be
     /// accepted. There is no prescription made as to the transactional
     /// guarantees of a call to `write`. Subsequent calls to `read` for the same
     /// `key` may or may not reflect the effect of a `write`, regardless of
@@ -158,7 +161,7 @@ pub trait InputOutput: Clone + Default + ConditionalSync + std::fmt::Debug {
     /// Get a mutable reference to the output [Data]
     fn output_mut(&mut self) -> &mut IoData;
 
-    /// Get the shape of the output, which is the expected [ValueKind] that maps
+    /// Get the shape of the output, which is the expected [`ValueKind`] that maps
     /// to each allowed key in the output space
     fn output_shape(&self) -> &IoShape;
 }
@@ -192,8 +195,8 @@ where
     }
 }
 
-/// An implementation of [InputOutput] that is suitable for use with many kinds
-/// of [crate::ModuleDriver].
+/// An implementation of [`InputOutput`] that is suitable for use with many kinds
+/// of [`ModuleDriver`].
 #[derive(Debug, Default, Clone)]
 pub struct BasicIo {
     input: IoData,
@@ -203,7 +206,7 @@ pub struct BasicIo {
 }
 
 impl BasicIo {
-    /// Instantiate a [RuntimeIo], providing initial input state, and the
+    /// Instantiate a [`BasicIo`], providing initial input state, and the
     /// expected shape of output state.
     pub fn new(input: IoData, output_shape: IoShape) -> Self {
         let label_constraints = Label::constrain(input.iter().map(|(_, v)| &v.label));
@@ -215,8 +218,8 @@ impl BasicIo {
         }
     }
 
-    /// Takes input values [IoValues] and an output shape [IoShape], and converts
-    /// the values into [Data] with strictest labels. Used for
+    /// Takes input values [`IoValues`] and an output shape [`IoShape`], and converts
+    /// the values into [`Data`] with strictest labels. Used for
     /// specifying initial state.
     pub fn from_initial_state(input_values: IoValues, output_shape: IoShape) -> Self {
         let mut map = BTreeMap::new();

--- a/rust/common-runtime/src/runtime/native/artifact.rs
+++ b/rust/common-runtime/src/runtime/native/artifact.rs
@@ -23,14 +23,14 @@ static JAVASCRIPT_COMMON_FUNCTION_INTERPRETER: Bytes = Bytes::from_static(includ
     "JAVASCRIPT_COMMON_FUNCTION_INTERPRETER_WASM_PATH"
 )));
 
-/// Well-known virtual module interpreters that may be requested from an [ArtifactResolver]
+/// Well-known virtual module interpreters that may be requested from an [`ArtifactResolver`]
 #[derive(Eq, PartialEq, Hash, Clone)]
 pub enum VirtualModuleInterpreter {
     /// A JavaScript interpreter that emulates a `common:function/module`
     JavaScriptFunction,
 }
 
-/// An [ArtifactResolver] is a one-stop shop for accessing
+/// An [`ArtifactResolver`] is a one-stop shop for accessing
 #[derive(Clone)]
 pub struct ArtifactResolver {
     builder_address: Option<Uri>,
@@ -39,7 +39,7 @@ pub struct ArtifactResolver {
 }
 
 impl ArtifactResolver {
-    /// Instantiate a new [ArtifactResolver], optionally providing a [Uri] that
+    /// Instantiate a new [`ArtifactResolver`], optionally providing a [`Uri`] that
     /// refers to a Builder gRPC server
     pub fn new(builder_address: Option<Uri>) -> Result<Self, CommonRuntimeError> {
         Ok(Self {
@@ -49,7 +49,7 @@ impl ArtifactResolver {
         })
     }
 
-    /// Look up the Wasm artifact for a well-known [VirtualModuleInterpreter]
+    /// Look up the Wasm artifact for a well-known [`VirtualModuleInterpreter`]
     pub async fn get_virtual_module_interpreter_wasm(
         &self,
         kind: VirtualModuleInterpreter,
@@ -61,7 +61,7 @@ impl ArtifactResolver {
         }
     }
 
-    /// Given a [ModuleDefinition], resolve the Wasm artifact represents the
+    /// Given a [`ModuleDefinition`], resolve the Wasm artifact represents the
     /// substantive implementation of the corresponding Module.
     pub async fn get_module_wasm(
         &self,
@@ -118,7 +118,7 @@ impl ArtifactResolver {
         }
     }
 
-    /// Given a [ModuleDefinition] with a [ModuleBody::SourceCode] body, resolve a bundled
+    /// Given a [`ModuleDefinition`] with a [ModuleBody::SourceCode] body, resolve a bundled
     /// artifact that combines all of its source code inputs
     pub async fn get_bundled_source_code(
         &self,

--- a/rust/common-runtime/src/serve/instantiate.rs
+++ b/rust/common-runtime/src/serve/instantiate.rs
@@ -13,8 +13,8 @@ use common_wit::Target;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-/// Instantiate a module using the provided [WasmtimeCompile] sandbox and cache the live instance
-/// in the provided [BTreeMap] against its instance ID.
+/// Instantiate a module using the provided[`WasmtimeCompile`] sandbox and cache the live instance
+/// in the provided[`BTreeMap`] against its instance ID.
 pub async fn instantiate_module(
     request: InstantiateModuleRequest,
     runtime: Arc<Mutex<NativeRuntime>>,

--- a/rust/common-runtime/src/serve/server.rs
+++ b/rust/common-runtime/src/serve/server.rs
@@ -30,7 +30,7 @@ pub struct Server {
 }
 
 impl Server {
-    /// Instantiate a new [Server]; the optional `builder_address` will be used
+    /// Instantiate a new[`Server`]; the optional `builder_address` will be used
     /// to attempt to JIT prepare not-yet-compiled Common Modules when needed.
     pub fn new(builder_address: Option<Uri>) -> Result<Self, CommonRuntimeError> {
         let artifact_resolver = ArtifactResolver::new(builder_address.clone())?;
@@ -101,7 +101,7 @@ const DEFAULT_ALLOW_HEADERS: [&str; 4] =
     ["x-grpc-web", "content-type", "x-user-agent", "grpc-timeout"];
 
 /// Start the Common Runtime server, listening to incoming connections on the
-/// provided [TcpListener]
+/// provided[`TcpListener`]
 pub async fn serve(
     listener: TcpListener,
     builder_address: Option<Uri>,

--- a/rust/common-runtime/src/value.rs
+++ b/rust/common-runtime/src/value.rs
@@ -15,7 +15,7 @@ pub enum Value {
 }
 
 impl Value {
-    /// Check if a [ValueKind] corresponds to the type of this [Value]
+    /// Check if a [`ValueKind`] corresponds to the type of this [`Value`]
     pub fn is_of_kind(&self, kind: &ValueKind) -> bool {
         match self {
             Value::String(_) if kind == &ValueKind::String => true,
@@ -27,7 +27,7 @@ impl Value {
     }
 }
 
-/// The set of variant types for [Value]
+/// The set of variant types for [`Value`]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum ValueKind {
     /// A UTF-8 string

--- a/rust/common-test-fixtures/src/server.rs
+++ b/rust/common-test-fixtures/src/server.rs
@@ -18,7 +18,7 @@ pub struct EsmTestServer {
 }
 
 impl EsmTestServer {
-    /// Create a new [ESMTestServer], serving the
+    /// Create a new [`EsmTestServer`], serving the
     /// `dir` directory at the host HTTP root "/".
     pub fn new<P: AsRef<Path>>(dir: P) -> Self {
         Self {
@@ -28,7 +28,7 @@ impl EsmTestServer {
     }
 
     /// Start the static server on `port`. Upon success, a
-    /// [SocketAddr] is returned of the static server.
+    /// [`SocketAddr`] is returned of the static server.
     pub async fn start_with_port(&mut self, port: u16) -> Result<SocketAddr> {
         let listener = TcpListener::bind((Ipv4Addr::new(127, 0, 0, 1), port)).await?;
         let addr = listener.local_addr()?;
@@ -43,13 +43,13 @@ impl EsmTestServer {
     }
 
     /// Start the static server, using an available port implicitly.
-    /// See [ESMTestServer::start_with_port] for more details.
+    /// See [`EsmTestServer::start_with_port`] for more details.
     pub async fn start(&mut self) -> Result<SocketAddr> {
         self.start_with_port(0).await
     }
 
     /// Terminates the static server. Called automatically when
-    /// [ESMTestServer] is dropped.
+    /// [`EsmTestServer`] is dropped.
     pub fn stop(&mut self) {
         if let Some(handle) = self.handle.take() {
             handle.abort();

--- a/rust/common-tools/src/commands.rs
+++ b/rust/common-tools/src/commands.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Entry point for CLI tool, taking a parsed [Cli] object.
+/// Entry point for CLI tool, taking a parsed [`Cli`] object.
 pub async fn exec_command(cli: Cli) -> Result<()> {
     use crate::cli::Command::*;
 
@@ -55,7 +55,7 @@ async fn run(module_path: PathBuf, port: u16, use_stdin: bool) -> Result<()> {
     Ok(())
 }
 
-/// Return the module found at `path` as a [String],
+/// Return the module found at `path` as a [`String`],
 /// normalizing for CLI usage.
 async fn module_from_path<P: AsRef<Path>>(path: P) -> Result<String> {
     let path_ref = path.as_ref();
@@ -134,8 +134,8 @@ async fn exec_module(
     }
 }
 
-/// Starts a [common_runtime] server listening on `runtime_port`,
-/// with a [common_builder] server.
+/// Starts a [`common_runtime`] server listening on `runtime_port`,
+/// with a [`common_builder`] server.
 async fn serve(runtime_port: u16) -> Result<()> {
     use common_builder::serve as serve_builder;
     use common_runtime::serve as serve_runtime;

--- a/rust/common-tracing/src/lib.rs
+++ b/rust/common-tracing/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate common_macros;
 
 /// Contains implementation for the `#[common_tracing]` macro.
-/// Prefer using the [common_tracing::common_tracing] macro over
+/// Prefer using the [`common_tracing`] macro over
 /// calling these functions directly.
 pub mod macro_impl;
 

--- a/rust/common-tracing/src/macro_impl.rs
+++ b/rust/common-tracing/src/macro_impl.rs
@@ -22,7 +22,7 @@ mod inner {
     static INITIALIZE_TRACING: Once = Once::new();
 
     /// Do not call directly.
-    /// See [common_tracing::common_tracing].
+    /// See [`common_tracing`].
     pub fn common_tracing_impl() {
         INITIALIZE_TRACING.call_once(|| {
             if let Err(error) = initialize_tracing_subscriber() {

--- a/rust/common-wit/src/lib.rs
+++ b/rust/common-wit/src/lib.rs
@@ -29,7 +29,7 @@ pub enum Target {
 }
 
 impl Target {
-    /// The presumptive WIT world that corresponds to a give [WitTarget]
+    /// The presumptive WIT world that corresponds to a given [`Target`]
     pub fn world(&self) -> &'static str {
         match self {
             Target::CommonFunction => "common:function/module",
@@ -68,7 +68,7 @@ impl std::fmt::Display for Target {
     }
 }
 
-/// A map of files that correspond to a give [WitTarget]
+/// A map of files that correspond to a give [`Target`]
 
 #[repr(transparent)]
 #[derive(Clone)]
@@ -81,7 +81,7 @@ impl AsRef<BTreeMap<String, &'static [u8]>> for WitTargetFileMap {
 }
 
 impl WitTargetFileMap {
-    /// Efficiently writes the files in the [WitTargetFileMap] to a target
+    /// Efficiently writes the files in the [`WitTargetFileMap`] to a target
     /// location on the local filesystem
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn write_to(self, target_directory: &std::path::Path) -> Result<(), std::io::Error> {


### PR DESCRIPTION
* Add cargo doc tests to CI
* fix doc links
* normalize doc links as enclosed in backticks and square brackets
* ignore rustfmt on generated bindings (can't repro locally with latest nightly https://github.com/commontoolsinc/system/actions/runs/10741097390/job/29790709344 )

replacement regex for reference: 

```
"s/\(\s\)\[\([A-Z_0-9a-z]*\)\]/\1[\`\\2\`]/g"
```