### PR TITLE
chore: Move Target from ModuleBody to the request scope.

### DIFF
--- a/proto/builder/builder.proto
+++ b/proto/builder/builder.proto
@@ -4,7 +4,10 @@ import public "common/common.proto";
 
 package builder;
 
-message BuildComponentRequest { common.ModuleSource module_source = 1; }
+message BuildComponentRequest {
+  common.ModuleSource module_source = 1;
+  common.Target target = 2;
+}
 
 message BuildComponentResponse { string id = 1; }
 
@@ -12,7 +15,10 @@ message ReadComponentRequest { string id = 1; }
 
 message ReadComponentResponse { bytes component = 1; }
 
-message BundleSourceCodeRequest { common.ModuleSource module_source = 1; }
+message BundleSourceCodeRequest {
+  common.ModuleSource module_source = 1;
+  common.Target target = 2;
+}
 
 message BundleSourceCodeResponse { string bundled_source_code = 1; }
 

--- a/proto/common/common.proto
+++ b/proto/common/common.proto
@@ -39,12 +39,17 @@ message SourceCode {
   bytes body = 2;
 }
 
+message ModuleBody {
+  oneof variant {
+    ModuleSignature module_signature = 1;
+    ModuleSource module_source = 2;
+  }
+}
+
 message ModuleSignature {
-  Target target = 1;
-  string id = 2;
+  string id = 1;
 }
 
 message ModuleSource {
-  Target target = 1;
-  map<string, SourceCode> source_code = 2;
+  map<string, SourceCode> source_code = 1;
 }

--- a/proto/runtime/runtime.proto
+++ b/proto/runtime/runtime.proto
@@ -16,6 +16,7 @@ message InstantiateModuleResponse { string instance_id = 1; }
 message RunModuleRequest {
   string instance_id = 1;
   map<string, common.LabeledData> input = 2;
+  bool keep_alive = 4;
 }
 
 message RunModuleResponse { map<string, common.LabeledData> output = 1; }

--- a/proto/runtime/runtime.proto
+++ b/proto/runtime/runtime.proto
@@ -5,13 +5,10 @@ import public "common/common.proto";
 package runtime;
 
 message InstantiateModuleRequest {
-  oneof module_reference {
-    common.ModuleSignature module_signature = 1;
-    common.ModuleSource module_source = 2;
-  }
-
-  map<string, common.ValueKind> output_shape = 4;
-  map<string, common.Value> default_input = 5;
+  common.ModuleBody module_reference = 1;
+  common.Target target = 2;
+  map<string, common.ValueKind> output_shape = 3;
+  map<string, common.Value> default_input = 4;
 }
 
 message InstantiateModuleResponse { string instance_id = 1; }

--- a/rust/common-builder/tests/server.rs
+++ b/rust/common-builder/tests/server.rs
@@ -29,8 +29,8 @@ async fn it_bundles_javascript() -> anyhow::Result<()> {
         bundled_source_code,
     } = client
         .bundle_source_code(BundleSourceCodeRequest {
+            target: Target::CommonFunction.into(),
             module_source: Some(ModuleSource {
-                target: Target::CommonFunction.into(),
                 source_code: [(
                     "module".to_owned(),
                     SourceCode {
@@ -68,8 +68,8 @@ async fn it_builds_javascript_modules() -> anyhow::Result<()> {
 
     let BuildComponentResponse { id } = client
         .build_component(BuildComponentRequest {
+            target: Target::CommonFunction.into(),
             module_source: Some(ModuleSource {
-                target: Target::CommonFunction.into(),
                 source_code: [(
                     "module".to_owned(),
                     SourceCode {

--- a/rust/common-integration-tests/tests/compiled_modules.rs
+++ b/rust/common-integration-tests/tests/compiled_modules.rs
@@ -51,6 +51,7 @@ async fn it_compiles_and_runs_an_uncompiled_module() -> Result<()> {
     let runtime::RunModuleResponse { output } = runtime_client
         .run_module(runtime::RunModuleRequest {
             instance_id,
+            keep_alive: false,
             input: [(
                 "foo".into(),
                 common::LabeledData {
@@ -138,6 +139,7 @@ async fn it_runs_a_precompiled_module() -> Result<()> {
     let runtime::RunModuleResponse { output } = runtime_client
         .run_module(runtime::RunModuleRequest {
             instance_id,
+            keep_alive: false,
             input: [(
                 "foo".into(),
                 common::LabeledData {

--- a/rust/common-integration-tests/tests/interpreted_modules.rs
+++ b/rust/common-integration-tests/tests/interpreted_modules.rs
@@ -24,10 +24,10 @@ async fn it_interprets_and_runs_a_common_script() -> Result<()> {
                 },
             )]
             .into(),
-            module_reference: Some(
-                runtime::instantiate_module_request::ModuleReference::ModuleSource(
+            target: common::Target::CommonFunctionVm.into(),
+            module_reference: Some(common::ModuleBody {
+                variant: Some(common::module_body::Variant::ModuleSource(
                     common::ModuleSource {
-                        target: common::Target::CommonFunctionVm.into(),
                         source_code: [(
                             "module".into(),
                             common::SourceCode {
@@ -37,8 +37,8 @@ async fn it_interprets_and_runs_a_common_script() -> Result<()> {
                         )]
                         .into(),
                     },
-                ),
-            ),
+                )),
+            }),
         })
         .await?
         .into_inner();

--- a/rust/common-integration-tests/tests/js_environment.rs
+++ b/rust/common-integration-tests/tests/js_environment.rs
@@ -123,10 +123,10 @@ async fn exec_module(
                 },
             )]
             .into(),
-            module_reference: Some(
-                runtime::instantiate_module_request::ModuleReference::ModuleSource(
+            target: common::Target::CommonFunctionVm.into(),
+            module_reference: Some(common::ModuleBody {
+                variant: Some(common::module_body::Variant::ModuleSource(
                     common::ModuleSource {
-                        target: common::Target::CommonFunctionVm.into(),
                         source_code: [(
                             "module".into(),
                             common::SourceCode {
@@ -136,8 +136,8 @@ async fn exec_module(
                         )]
                         .into(),
                     },
-                ),
-            ),
+                )),
+            }),
         })
         .await?
         .into_inner();

--- a/rust/common-integration-tests/tests/js_environment.rs
+++ b/rust/common-integration-tests/tests/js_environment.rs
@@ -145,6 +145,7 @@ async fn exec_module(
     let runtime::RunModuleResponse { output } = runtime_client
         .run_module(runtime::RunModuleRequest {
             instance_id,
+            keep_alive: false,
             input: [(
                 "input".into(),
                 common::LabeledData {

--- a/rust/common-protos/src/lib.rs
+++ b/rust/common-protos/src/lib.rs
@@ -17,6 +17,15 @@ pub mod common {
             }
         }
     }
+
+    impl From<Target> for common_wit::Target {
+        fn from(value: Target) -> Self {
+            match value {
+                Target::CommonFunction => common_wit::Target::CommonFunction,
+                Target::CommonFunctionVm => common_wit::Target::CommonFunctionVm,
+            }
+        }
+    }
 }
 
 /// Protobufs for the module builder.

--- a/rust/common-runtime/src/error.rs
+++ b/rust/common-runtime/src/error.rs
@@ -3,6 +3,10 @@ use common_ifc::CommonIfcError;
 use std::fmt::Debug;
 use thiserror::Error;
 
+/// [`std::result::Result`] type with [CommonRuntimeError]
+/// as its error.
+pub type Result<T> = ::std::result::Result<T, CommonRuntimeError>;
+
 /// Various errors that may be encountered when invoking runtime code.
 #[derive(Error, PartialEq, Debug)]
 pub enum CommonRuntimeError {

--- a/rust/common-runtime/src/module/definition.rs
+++ b/rust/common-runtime/src/module/definition.rs
@@ -39,6 +39,6 @@ pub struct ModuleDefinition {
 
 impl From<&ModuleDefinition> for ModuleId {
     fn from(value: &ModuleDefinition) -> Self {
-        (&value.target, &value.body).into()
+        (&value.body).into()
     }
 }

--- a/rust/common-runtime/src/module/driver.rs
+++ b/rust/common-runtime/src/module/driver.rs
@@ -4,19 +4,26 @@ use crate::CommonRuntimeError;
 
 use super::ModuleFactory;
 
-/// Runtime Module Drivers
+#[cfg(doc)]
+use crate::{Module, ModuleDefinition};
+
+/// Runtime Module Drivers.
 ///
 /// A [`ModuleDriver`] is implemented by a Runtime for each distinctive form of
-/// [crate::ModuleDefinition] that it is able to instantiate. The driver
-/// produces a prepared [`ModuleFactory`] for a given [crate::ModuleDefinition],
-/// which can in turn be used to instantiate a [crate::Module].
+/// [`ModuleDefinition`] that it is able to instantiate. The driver
+/// produces a prepared [`ModuleFactory`] for a given [`ModuleDefinition`],
+/// which can in turn be used to instantiate a [`Module`].
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait ModuleDriver<D> {
-    /// The type of the [`ModuleFactory`] that is produced by this [`ModuleDriver`]
+    /// The type of the [`ModuleFactory`] that is produced by this
+    /// [`ModuleDriver`].
     type ModuleFactory: ModuleFactory;
 
-    /// Prepare a Module, producing a [`ModuleFactory`] that may be used to instantiate an associated [crate::Module] many times (relatively cheaply).
-    /// Preparation typically entails resolving a Wasm artifact for the Module body, compiling that artifact and caching all the metadata required to instantiate it.
+    /// Prepare a Module, producing a [`ModuleFactory`] that may be used
+    /// to instantiate an associated [`Module`] many times (relatively cheaply).
+    /// Preparation typically entails resolving a Wasm artifact for the
+    /// Module body, compiling that artifact and caching all the metadata
+    /// required to instantiate it.
     async fn prepare(&self, definition: D) -> Result<Self::ModuleFactory, CommonRuntimeError>;
 }

--- a/rust/common-runtime/src/module/manager.rs
+++ b/rust/common-runtime/src/module/manager.rs
@@ -1,17 +1,20 @@
 use super::ModuleInstanceId;
 use async_trait::async_trait;
 
-/// [`ModuleManager`] is implemented for each distinctive [crate::Module] type
+#[cfg(doc)]
+use crate::Module;
+
+/// [`ModuleManager`] is implemented for each distinctive [`Module`] type
 /// that is tracked by the implementor. The implementor may then be used to keep
-/// instances of [crate::Module]s alive.
+/// instances of [`Module`]s alive.
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait ModuleManager<T> {
-    /// Track a [crate::Module] by retaining a reference to it
+    /// Track a [`Module`] by retaining a reference to it.
     async fn add(&self, module_instance: T) -> ModuleInstanceId;
-    /// Look up a tracked [crate::Module] by [`ModuleInstanceId`]
+    /// Look up a tracked [`Module`] by [`ModuleInstanceId`].
     async fn get(&self, id: &ModuleInstanceId) -> Option<T>;
-    /// Take a tracked [crate::Module]; the [`ModuleManager`] will no longer
-    /// retain a reference to it
-    async fn take(&self, id: ModuleInstanceId) -> Option<T>;
+    /// Take a tracked [`Module`]; the [`ModuleManager`] will no longer
+    /// retain a reference to it.
+    async fn take(&self, id: &ModuleInstanceId) -> Option<T>;
 }

--- a/rust/common-runtime/src/module/source_code.rs
+++ b/rust/common-runtime/src/module/source_code.rs
@@ -38,3 +38,15 @@ impl From<SourceCode> for common::SourceCode {
         (&value).into()
     }
 }
+
+impl<B> From<(ContentType, B)> for SourceCode
+where
+    B: Into<Bytes>,
+{
+    fn from(value: (ContentType, B)) -> Self {
+        SourceCode {
+            content_type: value.0,
+            body: value.1.into(),
+        }
+    }
+}

--- a/rust/common-runtime/src/runtime/native/artifact.rs
+++ b/rust/common-runtime/src/runtime/native/artifact.rs
@@ -81,8 +81,8 @@ impl ArtifactResolver {
             let id = if let ModuleBody::SourceCode(source_code_collection) = &definition.body {
                 let BuildComponentResponse { id } = builder_client
                     .build_component(tonic::Request::new(BuildComponentRequest {
+                        target: common_protos::common::Target::CommonFunction.into(),
                         module_source: Some(common_protos::common::ModuleSource {
-                            target: common_protos::common::Target::CommonFunction.into(),
                             source_code: source_code_collection
                                 .iter()
                                 .map(|(key, value)| (key.to_owned(), value.into()))
@@ -157,10 +157,8 @@ impl ArtifactResolver {
                 bundled_source_code,
             } = builder_client
                 .bundle_source_code(tonic::Request::new(BundleSourceCodeRequest {
-                    module_source: Some(common_protos::common::ModuleSource {
-                        target: target.into(),
-                        source_code,
-                    }),
+                    target: target.into(),
+                    module_source: Some(common_protos::common::ModuleSource { source_code }),
                 }))
                 .await
                 .map_err(|error| CommonRuntimeError::PreparationFailed(format!("{error}")))?

--- a/rust/common-runtime/src/runtime/web/remote/function/factory.rs
+++ b/rust/common-runtime/src/runtime/web/remote/function/factory.rs
@@ -6,11 +6,17 @@ use crate::{
     ModuleFactory, ModuleInstanceId, RemoteFunctionDefinition,
 };
 use async_trait::async_trait;
-use common_protos::runtime::{InstantiateModuleRequest, InstantiateModuleResponse};
+use common_protos::{
+    common,
+    runtime::{InstantiateModuleRequest, InstantiateModuleResponse},
+};
 use http::Uri;
 
-/// An implementor of [ModuleFactory] for [WebRemoteFunction] Modules that may be
-/// instantiated by a [crate::WebRuntime]
+#[cfg(doc)]
+use crate::{ModuleDefinition, WebRuntime};
+
+/// An implementor of [`ModuleFactory`] for [`WebRemoteFunction`] Modules that may be
+/// instantiated by a [`WebRuntime`]
 #[derive(Clone)]
 pub struct WebRemoteFunctionFactory {
     definition: Arc<RemoteFunctionDefinition>,
@@ -18,8 +24,8 @@ pub struct WebRemoteFunctionFactory {
 }
 
 impl WebRemoteFunctionFactory {
-    /// Instantiate a new [WebRemoteFunctionFactory] for a given
-    /// [crate::ModuleDefinition] and various Wasm runtime acoutrement
+    /// Instantiate a new [`WebRemoteFunctionFactory`] for a given
+    /// [`ModuleDefinition`] and various Wasm runtime acoutrement
     pub fn new(definition: RemoteFunctionDefinition, remote_runtime_address: Uri) -> Self {
         Self {
             remote_runtime_address,
@@ -44,12 +50,8 @@ impl ModuleFactory for WebRemoteFunctionFactory {
             .instantiate_module(InstantiateModuleRequest {
                 output_shape: context.io().output_shape().into(),
                 default_input: context.io().input().into(),
-                module_reference: Some(
-                    self.definition
-                        .inner()
-                        .body
-                        .to_module_reference(&self.definition.inner().target),
-                ),
+                target: common::Target::from(&self.definition.inner().target).into(),
+                module_reference: Some(self.definition.inner().body.to_owned().into()),
             })
             .await
             .map_err(|error| CommonRuntimeError::ModuleInstantiationFailed(format!("{error}")))?

--- a/rust/common-runtime/src/runtime/web/remote/function/module.rs
+++ b/rust/common-runtime/src/runtime/web/remote/function/module.rs
@@ -1,17 +1,18 @@
-use async_trait::async_trait;
-use common_protos::runtime::{RunModuleRequest, RunModuleResponse};
-use http::Uri;
-use std::sync::Arc;
-
+use super::WebRemoteFunctionContext;
 use crate::{
     remote::client::make_runtime_client, CommonRuntimeError, FunctionInterface, HasModuleContext,
     HasModuleContextMut, InputOutput, IoData, Module, ModuleContext, ModuleId, ModuleInstanceId,
     RemoteFunctionDefinition, Validated,
 };
+use async_trait::async_trait;
+use common_protos::runtime::{RunModuleRequest, RunModuleResponse};
+use http::Uri;
+use std::sync::Arc;
 
-use super::WebRemoteFunctionContext;
+#[cfg(doc)]
+use crate::{ModuleDefinition, WebRuntime};
 
-/// An `common:function/module`-based Module facade for the [crate::WebRuntime].
+/// An `common:function/module`-based Module facade for the [`WebRuntime`].
 pub struct WebRemoteFunction {
     module_id: ModuleId,
     instance_id: ModuleInstanceId,
@@ -20,7 +21,7 @@ pub struct WebRemoteFunction {
 }
 
 impl WebRemoteFunction {
-    /// Instantiate a [WebRemoteFunction] with a [crate::ModuleDefinition] and
+    /// Instantiate a [`WebRemoteFunction`] with a [`ModuleDefinition`] and
     /// remote Runtime session properties
     pub fn new(
         definition: Arc<RemoteFunctionDefinition>,
@@ -53,6 +54,7 @@ impl FunctionInterface for WebRemoteFunction {
             .run_module(RunModuleRequest {
                 instance_id: self.instance_id.to_string(),
                 input: io.into_inner().input().into(),
+                keep_alive: true,
             })
             .await
             .map_err(|error| CommonRuntimeError::ModuleRunFailed(format!("{error}")))?

--- a/rust/common-runtime/src/serve/live_modules.rs
+++ b/rust/common-runtime/src/serve/live_modules.rs
@@ -61,7 +61,7 @@ impl ModuleManager<Function> for LiveModules {
         self.functions.lock().await.get(id).cloned()
     }
 
-    async fn take(&self, id: ModuleInstanceId) -> Option<Function> {
-        self.functions.lock().await.remove(&id)
+    async fn take(&self, id: &ModuleInstanceId) -> Option<Function> {
+        self.functions.lock().await.remove(id)
     }
 }

--- a/rust/common-tools/src/commands.rs
+++ b/rust/common-tools/src/commands.rs
@@ -103,6 +103,7 @@ async fn exec_module(
     let input_io = input.unwrap_or_default();
     let runtime::RunModuleResponse { output } = runtime_client
         .run_module(runtime::RunModuleRequest {
+            keep_alive: false,
             instance_id,
             input: [(
                 "input".into(),

--- a/rust/common-tools/src/commands.rs
+++ b/rust/common-tools/src/commands.rs
@@ -4,8 +4,9 @@ use common_protos::{
     common,
     runtime::{self, runtime_client::RuntimeClient},
 };
-use common_runtime::Value;
+use common_runtime::{ContentType, ModuleBody, SourceCode, Value};
 use std::{
+    collections::BTreeMap,
     io::{stdin, Read},
     path::{Path, PathBuf},
 };
@@ -87,20 +88,13 @@ async fn exec_module(
                 },
             )]
             .into(),
+            target: common::Target::CommonFunctionVm.into(),
             module_reference: Some(
-                runtime::instantiate_module_request::ModuleReference::ModuleSource(
-                    common::ModuleSource {
-                        target: common::Target::CommonFunctionVm.into(),
-                        source_code: [(
-                            "module".into(),
-                            common::SourceCode {
-                                content_type: common::ContentType::JavaScript.into(),
-                                body: module_str.into(),
-                            },
-                        )]
-                        .into(),
-                    },
-                ),
+                ModuleBody::SourceCode(BTreeMap::from([(
+                    String::from("module"),
+                    SourceCode::from((ContentType::JavaScript, String::from(module_str))),
+                )]))
+                .into(),
             ),
         })
         .await?


### PR DESCRIPTION
We have an outstanding todo for ModuleBody to not own `Target`, and streamlines some conversions

Added keep alive flag to run module requests (#78)