### PR TITLE
Add darwin build support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
           let
             rustToolchain = pkgs.rust-bin.${toolchain}.latest.default.override {
               targets = [
+                "aarch64-apple-darwin"
                 "wasm32-unknown-unknown"
                 "wasm32-wasip1"
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
         pkgs = import nixpkgs {
           inherit system overlays;
         };
+        inherit (pkgs) lib stdenv darwin;
 
         /**
          * Helper function to select a Rust toolchain by name e.g., "stable", "nightly".
@@ -71,10 +72,11 @@
               wit-deps-cli
               rust-toolchain
               nodejs
-              chromium
-              chromedriver
               jco
 
+            ] ++ lib.optionals stdenv.isDarwin [
+              darwin.apple_sdk.frameworks.SystemConfiguration
+              darwin.apple_sdk.frameworks.Security
             ];
 
             shellHook = ''
@@ -104,7 +106,11 @@
         wit-deps-cli = pkgs.rustPlatform.buildRustPackage rec {
           pname = "wit-deps-cli";
           version = "0.3.4";
-          buildInputs = [ pkgs.rust-bin.stable.latest.default ];
+          buildInputs = [ pkgs.rust-bin.stable.latest.default ]
+                ++ lib.optionals stdenv.isDarwin [
+                  darwin.apple_sdk.frameworks.SystemConfiguration
+                  darwin.apple_sdk.frameworks.Security
+                ];
 
           src = pkgs.fetchCrate {
             inherit pname version;
@@ -120,7 +126,11 @@
             # NOTE: Version must be kept in sync with Cargo.toml
             # version of `wasm-bindgen` dependency!
             version = "0.2.93";
-            buildInputs = [ pkgs.rust-bin.stable.latest.default ];
+            buildInputs = [ pkgs.rust-bin.stable.latest.default ]
+                ++ lib.optionals stdenv.isDarwin [
+                    darwin.apple_sdk.frameworks.SystemConfiguration
+                    darwin.apple_sdk.frameworks.Security
+                ];
 
             src = pkgs.fetchCrate {
               inherit pname version;
@@ -162,6 +172,9 @@
               wit-deps-cli
               nodejs
               jco
+            ] ++ lib.optionals stdenv.isDarwin [
+                darwin.apple_sdk.frameworks.SystemConfiguration
+                darwin.apple_sdk.frameworks.Security
             ];
             cargoLock = {
               lockFile = ./Cargo.lock;

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
           name = "jco";
           src = ./typescript;
           dontNpmBuild = true;
-          npmDepsHash = "sha256-DFoNL5qRg39Tqz88P8rQ0slJjlfvfQzRvoJ32yZuZlU=";
+          npmDepsHash = "sha256-Nfhe2YyD7fhHoOiQEnrb8C6A0RfgOMa1xFqbTIAykyA=";
         };
 
         wit-deps-cli = pkgs.rustPlatform.buildRustPackage rec {

--- a/rust/common-integration-tests/build.rs
+++ b/rust/common-integration-tests/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    if let ("wasm32", "unknown", Some(_)) = (target_arch.as_str(), target_os.as_str(), std::option_env!("COMMON_BROWSER_INTEGRATION_TEST")) {
+        println!("cargo::rerun-if-env-changed=COMMON_RUNTIME_PORT");
+        println!("cargo::rerun-if-env-changed=COMMON_BUILDER_PORT");
+        println!("cargo:rustc-cfg=common_browser_integration_test");
+    };
+}

--- a/rust/common-integration-tests/build.rs
+++ b/rust/common-integration-tests/build.rs
@@ -2,7 +2,11 @@ fn main() {
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
 
-    if let ("wasm32", "unknown", Some(_)) = (target_arch.as_str(), target_os.as_str(), std::option_env!("COMMON_BROWSER_INTEGRATION_TEST")) {
+    if let ("wasm32", "unknown", Some(_)) = (
+        target_arch.as_str(),
+        target_os.as_str(),
+        std::option_env!("COMMON_BROWSER_INTEGRATION_TEST"),
+    ) {
         println!("cargo::rerun-if-env-changed=COMMON_RUNTIME_PORT");
         println!("cargo::rerun-if-env-changed=COMMON_BUILDER_PORT");
         println!("cargo:rustc-cfg=common_browser_integration_test");

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@bytecodealliance/componentize-js": "=0.9.0",
-        "@bytecodealliance/jco": "=1.5.0"
+        "@bytecodealliance/jco": "1.4.4"
       },
       "bin": {
         "jco": "node_modules/@bytecodealliance/jco/src/jco.js"
@@ -86,34 +86,6 @@
       }
     },
     "node_modules/@bytecodealliance/jco": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.5.0.tgz",
-      "integrity": "sha512-fTwAWpi6Om4fDILwXDz3da40kvF4weG4l0s7qVCknnz/uKfIn9eaSLBKDTVg1Gx5veqEAG7hb7FXQTWBpeK4mg==",
-      "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.11.3",
-        "@bytecodealliance/preview2-shim": "^0.16.5",
-        "binaryen": "^118.0.0",
-        "chalk-template": "^1",
-        "commander": "^12",
-        "mkdirp": "^3",
-        "ora": "^8",
-        "terser": "^5"
-      },
-      "bin": {
-        "jco": "src/jco.js"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/componentize-js": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.11.4.tgz",
-      "integrity": "sha512-infeu0iVWdUu/cJncWnAahq/jdIVypPUe6K9T6e0xVUGmPm0sVpij86AF0VjgD3y8UBHcE6Hv4e54AuRXe6rTw==",
-      "dependencies": {
-        "@bytecodealliance/jco": "1.4.4",
-        "@bytecodealliance/wizer": "^7.0.4",
-        "es-module-lexer": "^1.5.4"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/jco": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.4.4.tgz",
       "integrity": "sha512-Gu9VzU99rptKnRgx1KSMUIy56BoVWy6uKCoKZwLL+nvEM9kSLtvEp2CLSSnpOxXaFIpTLhmNhSu7j8h965C8zw==",
@@ -128,115 +100,6 @@
       },
       "bin": {
         "jco": "src/jco.js"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/wizer": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-7.0.4.tgz",
-      "integrity": "sha512-DaEoFCNxS4srJa9hqVkC2twvQqvvMWv4R+mEmTRtOB0Rt4d1hDcKJmjy/lIcrJHmzJu/dSZtTNaRpBwoCD/yLg==",
-      "bin": {
-        "wizer": "wizer.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@bytecodealliance/wizer-darwin-arm64": "7.0.4",
-        "@bytecodealliance/wizer-darwin-x64": "7.0.4",
-        "@bytecodealliance/wizer-linux-arm64": "7.0.4",
-        "@bytecodealliance/wizer-linux-s390x": "7.0.4",
-        "@bytecodealliance/wizer-linux-x64": "7.0.4",
-        "@bytecodealliance/wizer-win32-x64": "7.0.4"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/wizer-darwin-arm64": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-7.0.4.tgz",
-      "integrity": "sha512-9HO2k49riA+35i/av6pR3APdkCr6MSLZedmw4/106NPg6HTASoCx6pInNibUvVPah3ALMZAl4adjKUAOFdYuLw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "wizer-darwin-arm64": "wizer"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/wizer-darwin-x64": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-7.0.4.tgz",
-      "integrity": "sha512-/9QNAQ8/DCWpdb+S/gGMXdq/nw3Q/XUMvvn85T4N55lMj59XLgGE220cqWDueW1iiAFH/cNtJKjsy/Y3BSlP7g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "wizer-darwin-x64": "wizer"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/wizer-linux-arm64": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-arm64/-/wizer-linux-arm64-7.0.4.tgz",
-      "integrity": "sha512-EAIyuHR2EO/z2ecAMdBvtL3+fopOO2LZ9rTDaRX1MMJUv8D7lXYTSOksOiOnrMwsguRDIVbC1Z/ot5gw5LwoTw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "wizer-linux-arm64": "wizer"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/wizer-linux-s390x": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-s390x/-/wizer-linux-s390x-7.0.4.tgz",
-      "integrity": "sha512-otkIzM8H3ouub4ug1Y3ZhzywSiaHLiJzTLFm8tdK0l2397ygPmFKQycQxAM36+qFx58R8zDA63GZXOORbrYWeA==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "wizer-linux-s390x": "wizer"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/wizer-linux-x64": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-7.0.4.tgz",
-      "integrity": "sha512-SEBfjvl5S4eYEZOdyPs13TYX7873Ir1ZFS4mAM9b8dbAmx8p3hOITg2jBstCrIu7qSu3TrhOfv96tEMZDGoSKA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "wizer-linux-x64": "wizer"
-      }
-    },
-    "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/wizer-win32-x64": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-7.0.4.tgz",
-      "integrity": "sha512-Jp+/iOcvUuewGJr8aLozb1xVcIOCyv3/AL54Ir+mziWec6IA5hXwa6NZ5MY4GiQXcOryKfatzllP1JbqtYD4yw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "bin": {
-        "wizer-win32-x64": "wizer"
       }
     },
     "node_modules/@bytecodealliance/preview2-shim": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -10,7 +10,7 @@
     "./common/*"
   ],
   "dependencies": {
-    "@bytecodealliance/jco": "=1.5.0",
+    "@bytecodealliance/jco": "1.4.4",
     "@bytecodealliance/componentize-js": "=0.9.0"
   },
   "bin": {


### PR DESCRIPTION
SystemConfiguration was missing at link-time

```
brew install chromedriver
```

Ensure `Google Chrome.app` matches the version.

```
cargo test
```

then

```
CHROMEDRIVER=/opt/homebrew/bin/chromedriver \
WASM_BINDGEN_TEST_TIMEOUT=180 \
cargo test --target aarch64-apple-darwin  --package common-integration-tests
```