### PR TITLE
chore: silence 'cd -' output when running 'wit/wit-tools.sh deps'.

### DIFF
--- a/wit/wit-tools.sh
+++ b/wit/wit-tools.sh
@@ -25,11 +25,11 @@ print_help() {
 update_deps() {
     for wit in "${WITS[@]}"
     do
-        cd "$SCRIPT_DIR/common/$wit" && wit-deps && cd -
+        cd "$SCRIPT_DIR/common/$wit" && wit-deps && cd - > /dev/null
     done
     for component in "${WASM_COMPONENTS[@]}"
     do
-        cd "$SCRIPT_DIR/../$component" && wit-deps && cd -
+        cd "$SCRIPT_DIR/../$component" && wit-deps && cd - > /dev/null
     done
 }
 


### PR DESCRIPTION
When running `./wit/wit-tools.sh deps`, we'd get 4 lines of `cd -` spam:

```
$ ./wit/wit-tools.sh deps
/home/-/Dev/system
/home/-/Dev/system
/home/-/Dev/system
/home/-/Dev/system
```

This sounds stdout from the command to `/dev/null` -- errors still revealed
