### PR TITLE
chore: Disable nightly lints and macos nightly CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - toolchain: stable
-          - toolchain: nightly
+          # - toolchain: nightly
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -187,9 +187,9 @@ jobs:
           - platform: 'macos-13'
             toolchain: 'stable'
             flags: '--workspace --exclude common-integration-tests'
-          - platform: 'macos-13'
-            toolchain: 'nightly'
-            flags: '--workspace --exclude common-integration-tests'
+          # - platform: 'macos-13'
+          #  toolchain: 'nightly'
+          #  flags: '--workspace --exclude common-integration-tests'
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* Nightly lints block test execution for lint breakage in the future. We can deal with this as it comes to release or ad-hoc in the interim. Either way, not a blocker.
* We support development on macos, but not a top priority. Macos nightly tests take 40 minutes to run. Relaxing this for now.